### PR TITLE
Cannot select NET Core 3.1 anymore.

### DIFF
--- a/Instructions/Exercises/M05-Unit 6 Create a front door for a highly available web application using the Azure portal.md
+++ b/Instructions/Exercises/M05-Unit 6 Create a front door for a highly available web application using the Azure portal.md
@@ -42,7 +42,7 @@ This exercise requires two instances of a web application that run in different 
    | Resource group   | Select the resource group ContosoResourceGroup               |
    | Name             | Enter a unique Name for your web app. This example uses WebAppContoso-1. |
    | Publish          | Select **Code**.                                             |
-   | Runtime stack    | Select **.NET Core 3.1 (LTS)**.                              |
+   | Runtime stack    | Select **.NET Core 6 (LTS)**.                              |
    | Operating System | Select **Windows**.                                          |
    | Region           | Select **Central US**.                                       |
    | Windows Plan     | Select **Create new** and enter myAppServicePlanCentralUS in the text box. |
@@ -63,7 +63,7 @@ This exercise requires two instances of a web application that run in different 
    | Resource group   | Select the resource group ContosoResourceGroup               |
    | Name             | Enter a unique Name for your web app. This example uses WebAppContoso-2. |
    | Publish          | Select **Code**.                                             |
-   | Runtime stack    | Select **.NET Core 3.1 (LTS)**.                              |
+   | Runtime stack    | Select **.NET Core 6 (LTS)**.                              |
    | Operating System | Select **Windows**.                                          |
    | Region           | Select **East US**.                                          |
    | Windows Plan     | Select **Create new** and enter myAppServicePlanEastUS in the text box. |


### PR DESCRIPTION
Cannot select NET Core 3.1 anymore.

# Module: 05
## Lab/Demo: Module05-Unit6

Fixes # .

Changes proposed in this pull request:

-
-
-