### PR TITLE
Module 01 - Formatting Issues due to use of Pipe character

### DIFF
--- a/Instructions/Exercises/M01-Unit 4 Design and implement a Virtual Network in Azure.md
+++ b/Instructions/Exercises/M01-Unit 4 Design and implement a Virtual Network in Azure.md
@@ -3,6 +3,7 @@ Exercise:
     title: 'M01 - Unit 4 Design and implement a Virtual Network in Azure'
     module: 'Module 01 - Introduction to Azure Virtual Networks'
 ---
+
 # M01-Unit 4 Design and implement a Virtual Network in Azure
 
 ## Exercise scenario
@@ -59,104 +60,105 @@ In this exercise, you will:
 
 1. Go to [Azure portal](https://portal.azure.com/).
 
-2. On the home page, under **Azure services**, select **Resource groups**.  
+1. On the home page, under **Azure services**, select **Resource groups**.  
 
-3. In the Resource groups, select **+ Create**.
+1. In the Resource groups, select **+ Create**.
 
-4. Use the information in the following table to create the resource group.
+1. Use the information in the following table to create the resource group.
 
-| **Tab**         | **Option**                                 | **Value**            |
-| --------------- | ------------------------------------------ | -------------------- |
-| Basics          | Resource group                             | ContosoResourceGroup |
-|                 | Region                                     | (US) East US         |
-| Tags            | No changes required                        |                      |
-| Review + create | Review your settings and select **Create** |                      |
+   | **Tab**         | **Option**                                 | **Value**            |
+   | --------------- | ------------------------------------------ | -------------------- |
+   | Basics          | Resource group                             | ContosoResourceGroup |
+   |                 | Region                                     | (US) East US         |
+   | Tags            | No changes required                        |                      |
+   | Review + create | Review your settings and select **Create** |                      |
 
-5. In Resource groups, verify that **ContosoResourceGroup** appears in the list.
+1. In Resource groups, verify that **ContosoResourceGroup** appears in the list.
 
 ## Task 2: Create the CoreServicesVnet virtual network and subnets
 
 1. On the Azure portal home page, navigate to the Global Search bar and search **Virtual Networks** and select virtual networks under services.  ![Azure portal home page Global Search bar results for virtual network.](../media/global-search-bar.PNG)
-2. Select **Create** on the Virtual networks page.  ![Create a virtual network wizard.](../media/create-virtual-network.png)
-3. Use the information in the following table to create the CoreServicesVnet virtual network.  
+
+1. Select **Create** on the Virtual networks page.  ![Create a virtual network wizard.](../media/create-virtual-network.png)
+1. Use the information in the following table to create the CoreServicesVnet virtual network.  
    Remove or overwrite the default IP Address space. ![IP address configuration for Azure virtual network deployment ](../media/default-vnet-ip-address-range-annotated.png)
 
-| **Tab**      | **Option**         | **Value**            |
-| ------------ | ------------------ | -------------------- |
-| Basics       | Resource Group     | ContosoResourceGroup |
-|              | Name               | CoreServicesVnet     |
-|              | Region             | (US) East US         |
-| IP Addresses | IPv4 address space | 10.20.0.0/16         |
+   | **Tab**      | **Option**         | **Value**            |
+   | ------------ | ------------------ | -------------------- |
+   | Basics       | Resource Group     | ContosoResourceGroup |
+   |              | Name               | CoreServicesVnet     |
+   |              | Region             | (US) East US         |
+   | IP Addresses | IPv4 address space | 10.20.0.0/16         |
 
-4. Use the information in the following table to create the CoreServicesVnet subnets.
+1. Use the information in the following table to create the CoreServicesVnet subnets.
 
-5. To begin creating each subnet, select **+ Add subnet**. To finish creating each subnet, select **Add**.
+1. To begin creating each subnet, select **+ Add subnet**. To finish creating each subnet, select **Add**.
 
-| **Subnet**             | **Option**           | **Value**              |
-| ---------------------- | -------------------- | ---------------------- |
-| GatewaySubnet          | Subnet name          | GatewaySubnet          |
-|                        | Subnet address range | 10.20.0.0/27           |
-| SharedServicesSubnet   | Subnet name          | SharedServicesSubnet   |
-|                        | Subnet address range | 10.20.10.0/24          |
-| DatabaseSubnet         | Subnet name          | DatabaseSubnet         |
-|                        | Subnet address range | 10.20.20.0/24          |
-| PublicWebServiceSubnet | Subnet name          | PublicWebServiceSubnet |
-|                        | Subnet address range | 10.20.30.0/24          |
+   | **Subnet**             | **Option**           | **Value**              |
+   | ---------------------- | -------------------- | ---------------------- |
+   | GatewaySubnet          | Subnet name          | GatewaySubnet          |
+   |                        | Subnet address range | 10.20.0.0/27           |
+   | SharedServicesSubnet   | Subnet name          | SharedServicesSubnet   |
+   |                        | Subnet address range | 10.20.10.0/24          |
+   | DatabaseSubnet         | Subnet name          | DatabaseSubnet         |
+   |                        | Subnet address range | 10.20.20.0/24          |
+   | PublicWebServiceSubnet | Subnet name          | PublicWebServiceSubnet |
+   |                        | Subnet address range | 10.20.30.0/24          |
 
-6. To finish creating the CoreServicesVnet and its associated subnets, select **Review + create**.
+1. To finish creating the CoreServicesVnet and its associated subnets, select **Review + create**.
 
-7. Verify your configuration passed validation, and then select **Create**.
+1. Verify your configuration passed validation, and then select **Create**.
 
-8. Repeat steps 1 -8 for each VNet based on the tables below  
+1. Repeat steps 1 -8 for each VNet based on the tables below  
 
 ## Task 3: Create the ManufacturingVnet virtual network and subnets
 
-| **Tab**      | **Option**         | **Value**            |
-| ------------ | ------------------ | -------------------- |
-| Basics       | Resource Group     | ContosoResourceGroup |
-|              | Name               | ManufacturingVnet    |
-|              | Region             | (Europe) West Europe |
-| IP Addresses | IPv4 address space | 10.30.0.0/16         |
+   | **Tab**      | **Option**         | **Value**            |
+   | ------------ | ------------------ | -------------------- |
+   | Basics       | Resource Group     | ContosoResourceGroup |
+   |              | Name               | ManufacturingVnet    |
+   |              | Region             | (Europe) West Europe |
+   | IP Addresses | IPv4 address space | 10.30.0.0/16         |
 
-| **Subnet**                | **Option**           | **Value**                 |
-| ------------------------- | -------------------- | ------------------------- |
-| ManufacturingSystemSubnet | Subnet name          | ManufacturingSystemSubnet |
-|                           | Subnet address range | 10.30.10.0/24             |
-| SensorSubnet1             | Subnet name          | SensorSubnet1             |
-|                           | Subnet address range | 10.30.20.0/24             |
-| SensorSubnet2             | Subnet name          | SensorSubnet2             |
-|                           | Subnet address range | 10.30.21.0/24             |
-| SensorSubnet3             | Subnet name          | SensorSubnet3             |
-|                           | Subnet address range | 10.30.22.0/24             |
+   | **Subnet**                | **Option**           | **Value**                 |
+   | ------------------------- | -------------------- | ------------------------- |
+   | ManufacturingSystemSubnet | Subnet name          | ManufacturingSystemSubnet |
+   |                           | Subnet address range | 10.30.10.0/24             |
+   | SensorSubnet1             | Subnet name          | SensorSubnet1             |
+   |                           | Subnet address range | 10.30.20.0/24             |
+   | SensorSubnet2             | Subnet name          | SensorSubnet2             |
+   |                           | Subnet address range | 10.30.21.0/24             |
+   | SensorSubnet3             | Subnet name          | SensorSubnet3             |
+   |                           | Subnet address range | 10.30.22.0/24             |
 
 ## Task 4: Create the ResearchVnet virtual network and subnets
 
-| **Tab**      | **Option**         | **Value**            |
-| ------------ | ------------------ | -------------------- |
-| Basics       | Resource Group     | ContosoResourceGroup |
-|              | Name               | ResearchVnet         |
-|              | Region             | Southeast Asia       |
-| IP Addresses | IPv4 address space | 10.40.0.0/16         |
+   | **Tab**      | **Option**         | **Value**            |
+   | ------------ | ------------------ | -------------------- |
+   | Basics       | Resource Group     | ContosoResourceGroup |
+   |              | Name               | ResearchVnet         |
+   |              | Region             | Southeast Asia       |
+   | IP Addresses | IPv4 address space | 10.40.0.0/16         |
 
-| **Subnet**           | **Option**           | **Value**            |
-| -------------------- | -------------------- | -------------------- |
-| ResearchSystemSubnet | Subnet name          | ResearchSystemSubnet |
-|                      | Subnet address range | 10.40.0.0/24         |
+   | **Subnet**           | **Option**           | **Value**            |
+   | -------------------- | -------------------- | -------------------- |
+   | ResearchSystemSubnet | Subnet name          | ResearchSystemSubnet |
+   |                      | Subnet address range | 10.40.0.0/24         |
 
 ## Task 5: Verify the creation of VNets and Subnets
 
 1. On the Azure portal home page, select **All resources**.
 
-2. Verify that the CoreServicesVnet, ManufacturingVnet, and ResearchVnet are listed.
+1. Verify that the CoreServicesVnet, ManufacturingVnet, and ResearchVnet are listed.
 
-3. Select **CoreServicesVnet**.
+1. Select **CoreServicesVnet**.
 
-4. In CoreServicesVnet, under **Settings**, select **Subnets**.
+1. In CoreServicesVnet, under **Settings**, select **Subnets**.
 
-5. In CoreServicesVnet &#124; Subnets, verify that the subnets you created are listed, and that the IP address ranges are correct.
+1. In CoreServicesVnet &#124; Subnets, verify that the subnets you created are listed, and that the IP address ranges are correct.
 
    ![List of subnets in CoreServicesVnet.](../media/verify-subnets-annotated.png)
 
-6. Repeat steps 3 - 5 for each VNet.
+1. Repeat steps 3 - 5 for each VNet.
 
 Congratulations! You have successfully created a resource group, three VNets, and their associated subnets.

--- a/Instructions/Exercises/M01-Unit 4 Design and implement a Virtual Network in Azure.md
+++ b/Instructions/Exercises/M01-Unit 4 Design and implement a Virtual Network in Azure.md
@@ -79,7 +79,7 @@ In this exercise, you will:
 1. On the Azure portal home page, navigate to the Global Search bar and search **Virtual Networks** and select virtual networks under services.  ![Azure portal home page Global Search bar results for virtual network.](../media/global-search-bar.PNG)
 2. Select **Create** on the Virtual networks page.  ![Create a virtual network wizard.](../media/create-virtual-network.png)
 3. Use the information in the following table to create the CoreServicesVnet virtual network.  
-   ‎Remove or overwrite the default IP Address space![ip address configuration for azure virtual network deployment ](../media/default-vnet-ip-address-range-annotated.png)
+   Remove or overwrite the default IP Address space. ![IP address configuration for Azure virtual network deployment ](../media/default-vnet-ip-address-range-annotated.png)
 
 | **Tab**      | **Option**         | **Value**            |
 | ------------ | ------------------ | -------------------- |
@@ -88,9 +88,9 @@ In this exercise, you will:
 |              | Region             | (US) East US         |
 | IP Addresses | IPv4 address space | 10.20.0.0/16         |
 
- 4. Use the information in the following table to create the CoreServicesVnet subnets.
+4. Use the information in the following table to create the CoreServicesVnet subnets.
 
- 5. To begin creating each subnet, select **+ Add subnet**. To finish creating each subnet, select **Add**.
+5. To begin creating each subnet, select **+ Add subnet**. To finish creating each subnet, select **Add**.
 
 | **Subnet**             | **Option**           | **Value**              |
 | ---------------------- | -------------------- | ---------------------- |
@@ -103,11 +103,11 @@ In this exercise, you will:
 | PublicWebServiceSubnet | Subnet name          | PublicWebServiceSubnet |
 |                        | Subnet address range | 10.20.30.0/24          |
 
- 6. To finish creating the CoreServicesVnet and its associated subnets, select **Review + create**.
+6. To finish creating the CoreServicesVnet and its associated subnets, select **Review + create**.
 
- 7. Verify your configuration passed validation, and then select **Create**.
+7. Verify your configuration passed validation, and then select **Create**.
 
- 8. Repeat steps 1 -8 for each VNet based on the tables below  
+8. Repeat steps 1 -8 for each VNet based on the tables below  
 
 ## Task 3: Create the ManufacturingVnet virtual network and subnets
 
@@ -153,7 +153,7 @@ In this exercise, you will:
 
 4. In CoreServicesVnet, under **Settings**, select **Subnets**.
 
-5. In CoreServicesVnet | Subnets, verify that the subnets you created are listed, and that the IP address ranges are correct.
+5. In CoreServicesVnet &#124; Subnets, verify that the subnets you created are listed, and that the IP address ranges are correct.
 
    ![List of subnets in CoreServicesVnet.](../media/verify-subnets-annotated.png)
 

--- a/Instructions/Exercises/M01-Unit 4 Design and implement a Virtual Network in Azure.md
+++ b/Instructions/Exercises/M01-Unit 4 Design and implement a Virtual Network in Azure.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 01 - Introduction to Azure Virtual Networks'
 ---
 
-# M01-Unit 4 Design and implement a Virtual Network in Azure
+# M01 - Unit 4 Design and implement a Virtual Network in Azure
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M01-Unit 6 Configure DNS settings in Azure.md
+++ b/Instructions/Exercises/M01-Unit 6 Configure DNS settings in Azure.md
@@ -28,7 +28,7 @@ In this exercise, you will:
 1. Go to [Azure Portal](https://portal.azure.com/).
 
 2. On the Azure home page, in the search bar, enter dns, and then select **Private DNS zones**.  
-   ![Azure Portal home page with dns search.](../media/create-private-dns-zone.png)
+   ![Azure Portal home page with DNS search.](../media/create-private-dns-zone.png)
 
 3. In Private DNS zones, select **+ Create**.
 

--- a/Instructions/Exercises/M01-Unit 6 Configure DNS settings in Azure.md
+++ b/Instructions/Exercises/M01-Unit 6 Configure DNS settings in Azure.md
@@ -27,73 +27,73 @@ In this exercise, you will:
 
 1. Go to [Azure Portal](https://portal.azure.com/).
 
-2. On the Azure home page, in the search bar, enter dns, and then select **Private DNS zones**.  
+1. On the Azure home page, in the search bar, enter dns, and then select **Private DNS zones**.  
    ![Azure Portal home page with DNS search.](../media/create-private-dns-zone.png)
 
-3. In Private DNS zones, select **+ Create**.
+1. In Private DNS zones, select **+ Create**.
 
-4. Use the information in the following table to create the private DNS zone.
+1. Use the information in the following table to create the private DNS zone.
 
-| **Tab**         | **Option**                             | **Value**            |
-| --------------- | -------------------------------------- | -------------------- |
-| Basics          | Resource group                         | ContosoResourceGroup |
-|                 | Name                                   | Contoso.com          |
-| Tags            | No changes required                    |                      |
-| Review + create | Review your settings and select Create |                      |
+    | **Tab**         | **Option**                             | **Value**            |
+    | --------------- | -------------------------------------- | -------------------- |
+    | Basics          | Resource group                         | ContosoResourceGroup |
+    |                 | Name                                   | Contoso.com          |
+    | Tags            | No changes required                    |                      |
+    | Review + create | Review your settings and select Create |                      |
 
-5. Wait until the deployment is complete, and then select **Go to resource**.
+1. Wait until the deployment is complete, and then select **Go to resource**.
 
-6. Verify that the zone has been created.
+1. Verify that the zone has been created.
 
 ## Task 2: Link subnet for auto registration
 
 1. In Contoso.com, under **Settings**, select **Virtual network links**.
 
-2. On Contoso.com &#124; Virtual network links, select **+ Add**.
+1. On Contoso.com &#124; Virtual network links, select **+ Add**.
 
-![contoso.com &#124; Virtual links with + Add highlighted.](../media/add-network-link-dns.png)
+    ![contoso.com &#124; Virtual links with + Add highlighted.](../media/add-network-link-dns.png)
 
-3. Use the information in the following table to add the virtual network link.
+1. Use the information in the following table to add the virtual network link.
 
-| **Option**                          | **Value**                               |
-| ----------------------------------- | --------------------------------------- |
-| Link name                           | CoreServicesVnetLink                    |
-| Subscription                        | No changes required                     |
-| Virtual Network                     | CoreServicesVnet (ContosoResourceGroup) |
-| Enable auto registration            | Selected                                |
-| Review your settings and select OK. |                                         |
+    | **Option**                          | **Value**                               |
+    | ----------------------------------- | --------------------------------------- |
+    | Link name                           | CoreServicesVnetLink                    |
+    | Subscription                        | No changes required                     |
+    | Virtual Network                     | CoreServicesVnet (ContosoResourceGroup) |
+    | Enable auto registration            | Selected                                |
+    | Review your settings and select OK. |                                         |
 
-4. Select **Refresh**.
+1. Select **Refresh**.
 
-5. Verify that the CoreServicesVnetLink has been created, and that auto-registration is enabled.
+1. Verify that the CoreServicesVnetLink has been created, and that auto-registration is enabled.
 
-6. Repeat steps 2 - 5 for the ManufacturingVnet, using the information in the following table:
+1. Repeat steps 2 - 5 for the ManufacturingVnet, using the information in the following table:
 
-| **Option**                          | **Value**                                |
-| ----------------------------------- | ---------------------------------------- |
-| Link name                           | ManufacturingVnetLink                    |
-| Subscription                        | No changes required                      |
-| Virtual Network                     | ManufacturingVnet (ContosoResourceGroup) |
-| Enable auto registration            | Selected                                 |
-| Review your settings and select OK. |                                          |
+    | **Option**                          | **Value**                                |
+    | ----------------------------------- | ---------------------------------------- |
+    | Link name                           | ManufacturingVnetLink                    |
+    | Subscription                        | No changes required                      |
+    | Virtual Network                     | ManufacturingVnet (ContosoResourceGroup) |
+    | Enable auto registration            | Selected                                 |
+    | Review your settings and select OK. |                                          |
 
-7. Select **Refresh**.
+1. Select **Refresh**.
 
-8. Verify that the ManufacturingVnetLink has been created, and that auto-registration is enabled.
+1. Verify that the ManufacturingVnetLink has been created, and that auto-registration is enabled.
 
-9. Repeat steps 2 - 5 for the ResearchVnet, using the information in the following table:
+1. Repeat steps 2 - 5 for the ResearchVnet, using the information in the following table:
 
-| **Option**                          | **Value**                           |
-| ----------------------------------- | ----------------------------------- |
-| Link name                           | ResearchVnetLink                    |
-| Subscription                        | No changes required                 |
-| Virtual Network                     | ResearchVnet (ContosoResourceGroup) |
-| Enable auto registration            | Selected                            |
-| Review your settings and select OK. |                                     |
+    | **Option**                          | **Value**                           |
+    | ----------------------------------- | ----------------------------------- |
+    | Link name                           | ResearchVnetLink                    |
+    | Subscription                        | No changes required                 |
+    | Virtual Network                     | ResearchVnet (ContosoResourceGroup) |
+    | Enable auto registration            | Selected                            |
+    | Review your settings and select OK. |                                     |
 
-10. Select **Refresh**.
+1. Select **Refresh**.
 
-11. Verify that the ResearchVnetLink has been created, and that auto-registration is enabled.
+1. Verify that the ResearchVnetLink has been created, and that auto-registration is enabled.
 
 ## Task 3: Create Virtual Machines to test the configuration
 
@@ -103,9 +103,9 @@ In this section, you will create two test VMs to test the Private DNS zone confi
 
     > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
 
-2. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **azuredeploy.json** and **azuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M01**.
+1. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **azuredeploy.json** and **azuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M01**.
 
-3. Deploy the following ARM templates to create the VMs needed for this exercise:
+1. Deploy the following ARM templates to create the VMs needed for this exercise:
 
     >**Note**: You will be prompted to provide an Admin password.
 
@@ -115,21 +115,21 @@ In this section, you will create two test VMs to test the Private DNS zone confi
    New-AzResourceGroupDeployment -ResourceGroupName $RGName -TemplateFile azuredeploy.json -TemplateParameterFile azuredeploy.parameters.json
    ```
   
-4. When the deployment is complete, go to the Azure portal home page, and then select **Virtual Machines**.
+1. When the deployment is complete, go to the Azure portal home page, and then select **Virtual Machines**.
 
-5. Verify that both virtual machines have been created.
+1. Verify that both virtual machines have been created.
 
 ## Task 4: Verify records are present in the DNS zone
 
 1. On the Azure Portal home page, select **Private DNS zones**.
 
-2. On Private DNS zones, select **contoso.com**.
+1. On Private DNS zones, select **contoso.com**.
 
-3. Verify that host (A) records are listed for both VMs, as shown:
+1. Verify that host (A) records are listed for both VMs, as shown:
 
-![Contoso.com DNS zone showing auto-registered host A records.](../media/contoso_com-dns-zone.png)
+    ![Contoso.com DNS zone showing auto-registered host A records.](../media/contoso_com-dns-zone.png)
 
-4. Make a note of the names and IP addresses of the VMs.
+1. Make a note of the names and IP addresses of the VMs.
 
 ### Connect to the Test VMs using RDP
 

--- a/Instructions/Exercises/M01-Unit 6 Configure DNS settings in Azure.md
+++ b/Instructions/Exercises/M01-Unit 6 Configure DNS settings in Azure.md
@@ -28,7 +28,7 @@ In this exercise, you will:
 1. Go to [Azure Portal](https://portal.azure.com/).
 
 2. On the Azure home page, in the search bar, enter dns, and then select **Private DNS zones**.  
-   ‎![Azure Portal home page with dns search.](../media/create-private-dns-zone.png)
+   ![Azure Portal home page with dns search.](../media/create-private-dns-zone.png)
 
 3. In Private DNS zones, select **+ Create**.
 
@@ -49,9 +49,9 @@ In this exercise, you will:
 
 1. In Contoso.com, under **Settings**, select **Virtual network links**.
 
-2. On Contoso.com | Virtual network links, select **+ Add**.
+2. On Contoso.com &#124; Virtual network links, select **+ Add**.
 
-![contoso.com | Virtual links with + Add highlighted.](../media/add-network-link-dns.png)
+![contoso.com &#124; Virtual links with + Add highlighted.](../media/add-network-link-dns.png)
 
 3. Use the information in the following table to add the virtual network link.
 
@@ -153,7 +153,7 @@ In this section, you will create two test VMs to test the Private DNS zone confi
 
 1. On both VMs, if prompted, in **Networks**, select **Yes**.
 
-1. On TestVM1, open a command prompt and enter the command ipconfig /all.
+1. On TestVM1, open a command prompt and enter the command **ipconfig /all**.
 
 1. Verify that the IP address is the same as the one you noted in the DNS zone.
 

--- a/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
+++ b/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
@@ -31,11 +31,11 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 ### Create ManufacturingVM
 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
-  > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
+   > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
 
-1. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **ManufacturingVMazuredeploy.json** and **ManufacturingVMazuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M01**.
+2. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **ManufacturingVMazuredeploy.json** and **ManufacturingVMazuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M01**.
 
-1. Deploy the following ARM templates to create the VMs needed for this exercise:
+3. Deploy the following ARM templates to create the VMs needed for this exercise:
 
    >**Note**: You will be prompted to provide an Admin password.
 
@@ -45,9 +45,9 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
    New-AzResourceGroupDeployment -ResourceGroupName $RGName -TemplateFile ManufacturingVMazuredeploy.json -TemplateParameterFile ManufacturingVMazuredeploy.parameters.json
    ```
   
-1. When the deployment is complete, go to the Azure portal home page, and then select **Virtual Machines**.
+4. When the deployment is complete, go to the Azure portal home page, and then select **Virtual Machines**.
 
-1. Verify that the virtual machine has been created.
+5. Verify that the virtual machine has been created.
 
 ## Task 2: Connect to the Test VMs using RDP
 
@@ -57,7 +57,7 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 
 1. On ManufacturingVM, select **Connect &gt; RDP**.
 
-1. On ManufacturingVM | Connect, select **Download RDP file**.
+1. On ManufacturingVM &#124; Connect, select **Download RDP file**.
 
 1. Save the RDP file to your desktop.
 
@@ -69,7 +69,7 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 
 1. On TestVM1, select **Connect &gt; RDP**.
 
-1. On TestVM1 | Connect, select **Download RDP file**.
+1. On TestVM1 &#124; Connect, select **Download RDP file**.
 
 1. Save the RDP file to your desktop.
 
@@ -103,7 +103,7 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 1. In CoreServicesVnet, under **Settings**, select **Peerings**.
    ![screen shot of core services VNet Peering settings ](../media/create-peering-on-coreservicesvnet.png)
 
-1. On CoreServicesVnet | Peerings, select **+ Add**.
+1. On CoreServicesVnet &#124; Peerings, select **+ Add**.
 
 1. Use the information in the following table to create the peering.
 
@@ -126,9 +126,9 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 | Review your settings and select Add. |                                               |                                       |
 |                                      |                                               |                                       |
 
- >**Note**: If you don't have a "MOC Subscription", use the subscription you've been using previously. It's just a name.
+ >**Note**: If you don't have a "MOC Subscription", use the subscription you've been using previously.
 
-1. In CoreServicesVnet | Peerings, verify that the **CoreServicesVnet-to-ManufacturingVnet** peering is listed.
+1. In CoreServicesVnet &#124; Peerings, verify that the **CoreServicesVnet-to-ManufacturingVnet** peering is listed.
 
 1. Under Virtual networks, select **ManufacturingVnet**, and verify the **ManufacturingVnet-to-CoreServicesVnet** peering is listed.
 
@@ -159,4 +159,4 @@ Congratulations! You have successful configured connectivity between VNets by ad
    Remove-AzResourceGroup -Name 'ContosoResourceGroup' -Force -AsJob
    ```
 
-    >**Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.
+   >**Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.

--- a/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
+++ b/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
@@ -33,9 +33,9 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
    > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
 
-2. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **ManufacturingVMazuredeploy.json** and **ManufacturingVMazuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M01**.
+1. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **ManufacturingVMazuredeploy.json** and **ManufacturingVMazuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M01**.
 
-3. Deploy the following ARM templates to create the VMs needed for this exercise:
+1. Deploy the following ARM templates to create the VMs needed for this exercise:
 
    >**Note**: You will be prompted to provide an Admin password.
 
@@ -45,9 +45,9 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
    New-AzResourceGroupDeployment -ResourceGroupName $RGName -TemplateFile ManufacturingVMazuredeploy.json -TemplateParameterFile ManufacturingVMazuredeploy.parameters.json
    ```
   
-4. When the deployment is complete, go to the Azure portal home page, and then select **Virtual Machines**.
+1. When the deployment is complete, go to the Azure portal home page, and then select **Virtual Machines**.
 
-5. Verify that the virtual machine has been created.
+1. Verify that the virtual machine has been created.
 
 ## Task 2: Connect to the Test VMs using RDP
 
@@ -107,26 +107,26 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 
 1. Use the information in the following table to create the peering.
 
-| **Section**                          | **Option**                                    | **Value**                             |
-| ------------------------------------ | --------------------------------------------- | ------------------------------------- |
-| This virtual network                 |                                               |                                       |
-|                                      | Peering link name                             | CoreServicesVnet-to-ManufacturingVnet |
-|                                      | Traffic to remote virtual network             | Allow (default)                       |
-|                                      | Traffic forwarded from remote virtual network | Allow (default)                       |
-|                                      | Virtual network gateway or Route Server       | None (default)                        |
-| Remote virtual network               |                                               |                                       |
-|                                      | Peering link name                             | ManufacturingVnet-to-CoreServicesVnet |
-|                                      | Virtual network deployment model              | Resource manager                      |
-|                                      | I know my resource ID                         | Not selected                          |
-|                                      | Subscription                                  | Select the Subscription provided      |
-|                                      | Virtual network                               | ManufacturingVnet                     |
-|                                      | Traffic to remote virtual network             | Allow (default)                       |
-|                                      | Traffic forwarded from remote virtual network | Allow (default)                       |
-|                                      | Virtual network gateway or Route Server       | None (default)                        |
-| Review your settings and select Add. |                                               |                                       |
-|                                      |                                               |                                       |
+   | **Section**                          | **Option**                                    | **Value**                             |
+   | ------------------------------------ | --------------------------------------------- | ------------------------------------- |
+   | This virtual network                 |                                               |                                       |
+   |                                      | Peering link name                             | CoreServicesVnet-to-ManufacturingVnet |
+   |                                      | Traffic to remote virtual network             | Allow (default)                       |
+   |                                      | Traffic forwarded from remote virtual network | Allow (default)                       |
+   |                                      | Virtual network gateway or Route Server       | None (default)                        |
+   | Remote virtual network               |                                               |                                       |
+   |                                      | Peering link name                             | ManufacturingVnet-to-CoreServicesVnet |
+   |                                      | Virtual network deployment model              | Resource manager                      |
+   |                                      | I know my resource ID                         | Not selected                          |
+   |                                      | Subscription                                  | Select the Subscription provided      |
+   |                                      | Virtual network                               | ManufacturingVnet                     |
+   |                                      | Traffic to remote virtual network             | Allow (default)                       |
+   |                                      | Traffic forwarded from remote virtual network | Allow (default)                       |
+   |                                      | Virtual network gateway or Route Server       | None (default)                        |
+   | Review your settings and select Add. |                                               |                                       |
+   |                                      |                                               |                                       |
 
- >**Note**: If you don't have a "MOC Subscription", use the subscription you've been using previously.
+   >**Note**: If you don't have a "MOC Subscription", use the subscription you've been using previously.
 
 1. In CoreServicesVnet &#124; Peerings, verify that the **CoreServicesVnet-to-ManufacturingVnet** peering is listed.
 

--- a/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
+++ b/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
@@ -3,7 +3,8 @@ Exercise:
     title: 'M01 - Unit 8 Connect two Azure Virtual Networks using global virtual network peering'
     module: 'Module 01 - Introduction to Azure Virtual Networks'
 ---
-# M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering
+
+# M01 - Unit 8 Connect two Azure Virtual Networks using global virtual network peering
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M02-Unit 3 Create and configure a virtual network gateway.md
+++ b/Instructions/Exercises/M02-Unit 3 Create and configure a virtual network gateway.md
@@ -35,7 +35,7 @@ In this exercise, you will:
 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
 
- > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
+   > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
 
 1. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **azuredeploy.json** and **azuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M02**
 
@@ -95,13 +95,13 @@ In this exercise, you will:
 1. On the Azure Portal home page, select **Virtual Machines**.
 1. Select **ManufacturingVM**.
 1. On **ManufacturingVM**, select **Connect &gt; RDP**.
-1. On **ManufacturingVM | Connect**, select **Download RDP file**.
+1. On **ManufacturingVM &#124; Connect**, select **Download RDP file**.
 1. Save the RDP file to your desktop.
 1. Connect to **ManufacturingVM** using the RDP file, and the username **TestUser** and the password you provided during deployment. After connecting, minimize the RDP session.
 1. On the Azure Portal home page, select **Virtual Machines**.
 1. Select **CoreServicesVM**.
 1. On **CoreServicesVM**, select **Connect &gt; RDP**.
-1. On **CoreServicesVM | Connect**, select **Download RDP file**.
+1. On **CoreServicesVM &#124; Connect**, select **Download RDP file**.
 1. Save the RDP file to your desktop.
 1. Connect to **CoreServicesVM** using the RDP file, and the username **TestUser** and the password you provided during deployment.
 1. On both VMs, in **Choose privacy settings for your device**, select **Accept**.
@@ -151,7 +151,7 @@ In this exercise, you will:
    |                 |                   | Configure BGP                               | Disabled                     |
    | Review + create |                   | Review your settings and select **Create**. |                              |
 
-   > [!NOTE]
+   > **NOTE**
    >
    > It can take up to 45 minutes to create a virtual network gateway.
 
@@ -182,7 +182,7 @@ In this exercise, you will:
    |                 |                   | Configure BGP                               | Disabled                     |
    | Review + create |                   | Review your settings and select **Create**. |                              |
 
-   > [!NOTE]
+   > **NOTE**
    >
    > It can take up to 45 minutes to create a virtual network gateway.
 
@@ -194,9 +194,9 @@ In this exercise, you will:
 
 1. In CoreServicesGateway, select **Connections**, and then select **+ Add**.
 
-   > [!NOTE]
+   > **NOTE**
    >
-   >  You will not be able to complete this configuration until the virtual network gateways are fully deployed.
+   > You will not be able to complete this configuration until the virtual network gateways are fully deployed.
 
 1. Use the information in the following table to create the connection:
 
@@ -244,7 +244,7 @@ In this exercise, you will:
 
 ## Task 10: Verify that the connections connect
 
-1. In **Search resources, services, and docs (G+/)**, enter **connections**, and then select **connections** from the results.
+1. In **Search resources, services, and docs (G+/)**, enter **connections**, and then select **Connections** from the results.
 
 1. Wait until the status of both connections is **Connected**. You may need to refresh your screen.
 

--- a/Instructions/Exercises/M02-Unit 3 Create and configure a virtual network gateway.md
+++ b/Instructions/Exercises/M02-Unit 3 Create and configure a virtual network gateway.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 02 - Design and implement hybrid networking'
 ---
 
-# M02-Unit 3 Create and configure a virtual network gateway
+# M02 - Unit 3 Create and configure a virtual network gateway
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M02-Unit 3 Create and configure a virtual network gateway.md
+++ b/Instructions/Exercises/M02-Unit 3 Create and configure a virtual network gateway.md
@@ -4,7 +4,6 @@ Exercise:
     module: 'Module 02 - Design and implement hybrid networking'
 ---
 
-
 # M02-Unit 3 Create and configure a virtual network gateway
 
 ## Exercise scenario

--- a/Instructions/Exercises/M02-Unit 7 Create a Virtual WAN by using Azure Portal.md
+++ b/Instructions/Exercises/M02-Unit 7 Create a Virtual WAN by using Azure Portal.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 02 - Design and implement hybrid networking'
 ---
 
-# M02-Unit 7 Create a Virtual WAN by using Azure Portal
+# M02 - Unit 7 Create a Virtual WAN by using Azure Portal
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M02-Unit 7 Create a Virtual WAN by using Azure Portal.md
+++ b/Instructions/Exercises/M02-Unit 7 Create a Virtual WAN by using Azure Portal.md
@@ -81,7 +81,7 @@ A hub contains gateways for site-to-site, ExpressRoute, or point-to-site functio
 
    ![Virtual WAN configuration page with Virtual network connections highlighted.](../media/connect-vnet-to-virtual-hub.png)
 
-1. On ContosoVirtualWAN | Virtual network connections, select **+ Add connection**.
+1. On ContosoVirtualWAN &#124; Virtual network connections, select **+ Add connection**.
 
 1. In Add connection, use the following information to create the connection.
 
@@ -105,7 +105,7 @@ Congratulations! You have created a Virtual WAN and a Virtual WAN Hub and connec
 
 ## Task 4: Clean up resources
 
-   >**Note**: Remember to remove any newly created Azure resources that you no longer use. Removing unused resources ensures you will not see unexpected charges.
+   > **Note**: Remember to remove any newly created Azure resources that you no longer use. Removing unused resources ensures you will not see unexpected charges.
 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
 
@@ -115,4 +115,4 @@ Congratulations! You have created a Virtual WAN and a Virtual WAN Hub and connec
    Remove-AzResourceGroup -Name 'ContosoResourceGroup' -Force -AsJob
    ```
 
-    >**Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.
+    > **Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.

--- a/Instructions/Exercises/M02-Unit 7 Create a Virtual WAN by using Azure Portal.md
+++ b/Instructions/Exercises/M02-Unit 7 Create a Virtual WAN by using Azure Portal.md
@@ -115,4 +115,4 @@ Congratulations! You have created a Virtual WAN and a Virtual WAN Hub and connec
    Remove-AzResourceGroup -Name 'ContosoResourceGroup' -Force -AsJob
    ```
 
-    > **Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.
+   > **Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.

--- a/Instructions/Exercises/M03-Unit 4 Configure an ExpressRoute Gateway.md
+++ b/Instructions/Exercises/M03-Unit 4 Configure an ExpressRoute Gateway.md
@@ -15,8 +15,6 @@ To connect your Azure virtual network and your on-premises network via ExpressRo
 
 ### Estimated time: 60 minutes (includes ~45 minutes deployment waiting time)
 
-**Gateway types**
-
 When you create a virtual network gateway, you need to specify several settings. One of the required settings, '-GatewayType', specifies whether the gateway is used for ExpressRoute, or VPN traffic. The two gateway types are:
 
 - **VPN** - To send encrypted traffic across the public Internet, you use the gateway type 'VPN'. This is also referred to as a VPN gateway. Site-to-Site, Point-to-Site, and VNet-to-VNet connections all use a VPN gateway.
@@ -62,7 +60,7 @@ In this exercise, you will:
 
 1. Confirm that the VNet passes the validation and then select **Create**.
 
-> [!Note]  
+> **NOTE**
 >
 > If you are using a dual stack virtual network and plan to use IPv6-based private peering over ExpressRoute, select Add IP6 address space and input IPv6 address range values.
 
@@ -96,8 +94,8 @@ In this exercise, you will:
 
 1. When the deployment is complete, select **Go to Resource**.
 
-> [!Note]
+> **NOTE**
 >
-> it can take up to 45 minutes to deploy a Gateway.
+> It can take up to 45 minutes to deploy an ExpressRoute Gateway.
 
 Congratulations! You have successfully created a Virtual network, a gateway subnet, and an ExpressRoute Gateway.

--- a/Instructions/Exercises/M03-Unit 4 Configure an ExpressRoute Gateway.md
+++ b/Instructions/Exercises/M03-Unit 4 Configure an ExpressRoute Gateway.md
@@ -3,6 +3,7 @@ Exercise:
     title: 'M03 - Unit 4 Configure an ExpressRoute Gateway'
     module: 'Module 03 - Design and implement Azure ExpressRoute'
 ---
+
 # M03-Unit 4 Configure an ExpressRoute Gateway
 
 ## Exercise scenario

--- a/Instructions/Exercises/M03-Unit 4 Configure an ExpressRoute Gateway.md
+++ b/Instructions/Exercises/M03-Unit 4 Configure an ExpressRoute Gateway.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 03 - Design and implement Azure ExpressRoute'
 ---
 
-# M03-Unit 4 Configure an ExpressRoute Gateway
+# M03 - Unit 4 Configure an ExpressRoute Gateway
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M03-Unit 5 Provision an ExpressRoute circuit.md
+++ b/Instructions/Exercises/M03-Unit 5 Provision an ExpressRoute circuit.md
@@ -3,6 +3,7 @@ Exercise:
     title: 'M03 - Unit 5 Provision an ExpressRoute circuit'
     module: 'Module 03 - Design and implement Azure ExpressRoute'
 ---
+
 # M03-Unit 5 Provision an ExpressRoute circuit
 
 ## Exercise scenario
@@ -42,30 +43,30 @@ In this exercise, you will:
 
 1. Confirm that the ExpressRoute configuration passes validation and then select **Create**.
 
-![Azure portal - Create ExpressRoute configuration tab](../media/expressroute-create-configuration2.png)
+   ![Azure portal - Create ExpressRoute configuration tab](../media/expressroute-create-configuration2.png)
 
-+ Port type determines if you are connecting to a service provider or directly into Microsoft's global network at a peering location.
-+ Create new or import from classic determines if a new circuit is being created or if you are migrating a classic circuit to Azure Resource Manager.
-+ Provider is the internet service provider who you will be requesting your service from.
-+ Peering Location is the physical location where you are peering with Microsoft.
+   + Port type determines if you are connecting to a service provider or directly into Microsoft's global network at a peering location.
+   + Create new or import from classic determines if a new circuit is being created or if you are migrating a classic circuit to Azure Resource Manager.
+   + Provider is the internet service provider who you will be requesting your service from.
+   + Peering Location is the physical location where you are peering with Microsoft.
 
-> **IMPORTANT**
->
-> The Peering Location indicates the [physical location](https://docs.microsoft.com/en-us/azure/expressroute/expressroute-locations) where you are peering with Microsoft. This is not linked to "Location" property, which refers to the geography where the Azure Network Resource Provider is located. While they are not related, it is a good practice to choose a Network Resource Provider geographically close to the Peering Location of the circuit.
+   > **IMPORTANT**
+   >
+   > The Peering Location indicates the [physical location](https://docs.microsoft.com/en-us/azure/expressroute/expressroute-locations) where you are peering with Microsoft. This is not linked to "Location" property, which refers to the geography where the Azure Network Resource Provider is located. While they are not related, it is a good practice to choose a Network Resource Provider geographically close to the Peering Location of the circuit.
 
-+ **SKU** determines whether an ExpressRoute local, ExpressRoute standard, or an ExpressRoute premium add-on is enabled. You can specify **Local** to get the local SKU, **Standard** to get the standard SKU or **Premium** for the premium add-on. You can change the SKU to enable the premium add-on.
+   + **SKU** determines whether an ExpressRoute local, ExpressRoute standard, or an ExpressRoute premium add-on is enabled. You can specify **Local** to get the local SKU, **Standard** to get the standard SKU or **Premium** for the premium add-on. You can change the SKU to enable the premium add-on.
 
-> **IMPORTANT**
->
-> You cannot change the SKU from Standard/Premium to Local.
+   > **IMPORTANT**
+   >
+   > You cannot change the SKU from Standard/Premium to Local.
 
-+ **Billing model** determines the billing type. You can specify **Metered** for a metered data plan and **Unlimited** for an unlimited data plan. You can change the billing type from **Metered** to **Unlimited**.
+   + **Billing model** determines the billing type. You can specify **Metered** for a metered data plan and **Unlimited** for an unlimited data plan. You can change the billing type from **Metered** to **Unlimited**.
 
-> **IMPORTANT**
->
-> You cannot change the type from Unlimited to Metered.
+   > **IMPORTANT**
+   >
+   > You cannot change the type from Unlimited to Metered.
 
-+ **Allow classic operation** will allow classic virtual networks to be link to the circuit.
+   + **Allow classic operation** will allow classic virtual networks to be link to the circuit.
 
 ## Task 2: Retrieve your Service key
 
@@ -96,7 +97,7 @@ In this exercise, you will:
      + Circuit status: Enabled
    + You should periodically check the provisioning status and the state of the circuit status.
 
-![Azure portal - ExpressRoute circuit properties showing status is now provisioned](../media/provisioned.png)
+   ![Azure portal - ExpressRoute circuit properties showing status is now provisioned](../media/provisioned.png)
 
 Congratulations! You have created an ExpressRoute circuit and located the Service key, which you would need to complete the provisioning of the circuit.
 

--- a/Instructions/Exercises/M03-Unit 5 Provision an ExpressRoute circuit.md
+++ b/Instructions/Exercises/M03-Unit 5 Provision an ExpressRoute circuit.md
@@ -26,7 +26,7 @@ In this exercise, you will:
 
 1. From a browser, navigate to the [Azure portal](https://portal.azure.com/) and sign in with your Azure account.
 
-   > [!Important]
+   > **IMPORTANT**
    >
    > Your ExpressRoute circuit is billed from the moment a service key is issued. Ensure that you perform this operation when the connectivity provider is ready to provision the circuit.
 
@@ -49,19 +49,19 @@ In this exercise, you will:
 + Provider is the internet service provider who you will be requesting your service from.
 + Peering Location is the physical location where you are peering with Microsoft.
 
-> [!Important]
+> **IMPORTANT**
 >
 > The Peering Location indicates the [physical location](https://docs.microsoft.com/en-us/azure/expressroute/expressroute-locations) where you are peering with Microsoft. This is not linked to "Location" property, which refers to the geography where the Azure Network Resource Provider is located. While they are not related, it is a good practice to choose a Network Resource Provider geographically close to the Peering Location of the circuit.
 
 + **SKU** determines whether an ExpressRoute local, ExpressRoute standard, or an ExpressRoute premium add-on is enabled. You can specify **Local** to get the local SKU, **Standard** to get the standard SKU or **Premium** for the premium add-on. You can change the SKU to enable the premium add-on.
 
-> [!Important]
+> **IMPORTANT**
 >
 > You cannot change the SKU from Standard/Premium to Local.
 
 + **Billing model** determines the billing type. You can specify **Metered** for a metered data plan and **Unlimited** for an unlimited data plan. You can change the billing type from **Metered** to **Unlimited**.
 
-> [!Important]
+> **IMPORTANT**
 >
 > You cannot change the type from Unlimited to Metered.
 
@@ -104,7 +104,7 @@ Congratulations! You have created an ExpressRoute circuit and located the Servic
 
 If the ExpressRoute circuit service provider provisioning state is **Provisioning** or **Provisioned,** you must work with your service provider to deprovision the circuit on their side. Microsoft can continue to reserve resources and bill you until the service provider completes deprovisioning the circuit and notifies us.
 
-> [!Note]
+> **NOTE**
 >
 > You must unlink all virtual networks from the ExpressRoute circuit before deprovisioning. If this operation fails, check whether any virtual networks are linked to the circuit.
 >
@@ -116,7 +116,7 @@ You can delete your ExpressRoute circuit by selecting the **Delete** icon. Ensur
 
 ![Azure portal - delete an ExpressRoute circuit](../media/expressroute-circuit-delete.png)
 
-   >**Note**: Remember to remove any newly created Azure resources that you no longer use. Removing unused resources ensures you will not see unexpected charges.
+   > **Note**: Remember to remove any newly created Azure resources that you no longer use. Removing unused resources ensures you will not see unexpected charges.
 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
 
@@ -127,4 +127,4 @@ You can delete your ExpressRoute circuit by selecting the **Delete** icon. Ensur
    Remove-AzResourceGroup -Name 'ExpressRouteResourceGroup' -Force -AsJob
    ```
 
-   >**Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.
+   > **Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.

--- a/Instructions/Exercises/M03-Unit 5 Provision an ExpressRoute circuit.md
+++ b/Instructions/Exercises/M03-Unit 5 Provision an ExpressRoute circuit.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 03 - Design and implement Azure ExpressRoute'
 ---
 
-# M03-Unit 5 Provision an ExpressRoute circuit
+# M03 - Unit 5 Provision an ExpressRoute circuit
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M04-Unit 4 Create and configure an Azure load balancer.md
+++ b/Instructions/Exercises/M04-Unit 4 Create and configure an Azure load balancer.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 04 - Load balancing non-HTTP(S) traffic in Azure'
 ---
 
-# M04-Unit 4 Create and configure an Azure load balancer
+# M04 - Unit 4 Create and configure an Azure load balancer
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M04-Unit 4 Create and configure an Azure load balancer.md
+++ b/Instructions/Exercises/M04-Unit 4 Create and configure an Azure load balancer.md
@@ -4,8 +4,9 @@ Exercise:
     module: 'Module 04 - Load balancing non-HTTP(S) traffic in Azure'
 ---
 
-
 # M04-Unit 4 Create and configure an Azure load balancer
+
+## Exercise scenario
 
 In this exercise, you will create an internal load balancer for the fictional Contoso Ltd organization.
 
@@ -31,11 +32,11 @@ In this section, you will create a virtual network and a subnet.
 
 1. Log in to the Azure portal.
 
-2. On the Azure portal home page, navigate to the Global Search bar and search **Virtual Networks** and select virtual networks under services.  ![Azure portal home page Global Search bar results for virtual network.](../media/global-search-bar.PNG)
+1. On the Azure portal home page, navigate to the Global Search bar and search **Virtual Networks** and select virtual networks under services.  ![Azure portal home page Global Search bar results for virtual network.](../media/global-search-bar.PNG)
 
-3. Select **Create** on the Virtual networks page.  ![Create a virtual network wizard.](../media/create-virtual-network.png)
+1. Select **Create** on the Virtual networks page.  ![Create a virtual network wizard.](../media/create-virtual-network.png)
 
-4. On the **Basics** tab, use the information in the table below to create the virtual network.
+1. On the **Basics** tab, use the information in the table below to create the virtual network.
 
    | **Setting**    | **Value**                                  |
    | -------------- | ------------------------------------------ |
@@ -44,21 +45,21 @@ In this section, you will create a virtual network and a subnet.
    | Name           | **IntLB-VNet**                             |
    | Region         | **(US) East US**                           |
 
-5. Select **Next : IP Addresses**.
+1. Select **Next : IP Addresses**.
 
-6. On the **IP Addresses** tab, in the **IPv4 address space** box, remove the default and enter **10.1.0.0/16**.
+1. On the **IP Addresses** tab, in the **IPv4 address space** box, remove the default and enter **10.1.0.0/16**.
 
-7. On the **IP Addresses** tab, select **+ Add subnet**.
+1. On the **IP Addresses** tab, select **+ Add subnet**.
 
-8. In the **Add subnet** pane, provide a subnet name of **myBackendSubnet**, and a subnet address range of **10.1.0.0/24**.
+1. In the **Add subnet** pane, provide a subnet name of **myBackendSubnet**, and a subnet address range of **10.1.0.0/24**.
 
-9. Select **Add**.
+1. Select **Add**.
 
-10. Select **Add subnet**, provide a subnet name of **myFrontEndSubnet**, and a subnet address range of **10.1.2.0/24**. Select **Add**
+1. Select **Add subnet**, provide a subnet name of **myFrontEndSubnet**, and a subnet address range of **10.1.2.0/24**. Select **Add**
 
-11. Select **Next : Security**.
+1. Select **Next : Security**.
 
-12. Under **BastionHost** select **Enable**, then enter the information from the table below.
+1. Under **BastionHost** select **Enable**, then enter the information from the table below.
 
     | **Setting**                       | **Value**                                     |
     | --------------------------------- | --------------------------------------------- |
@@ -66,9 +67,9 @@ In this section, you will create a virtual network and a subnet.
     | AzureBastionSubnet address  space | **10.1.1.0/26**                               |
     | Public IP address                 | Select **Create  new**  Name: **myBastionIP** |
 
-13. Select **Review + create**.
+1. Select **Review + create**.
 
-14. Select **Create**.
+1. Select **Create**.
 
 ## Task 2: Create backend servers
 
@@ -76,13 +77,13 @@ In this section, you will create three VMs, that will be in the same availabilit
 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
 
- > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
+   > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
 
-2. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files azuredeploy.json, and azuredeploy.parameters.json into the Cloud Shell home directory one by one.
+1. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files azuredeploy.json, and azuredeploy.parameters.json into the Cloud Shell home directory one by one.
 
-3. Deploy the following ARM templates to create the VMs needed for this exercise:
+1. Deploy the following ARM templates to create the VMs needed for this exercise:
 
->**Note**: You will be prompted to provide an Admin password.
+   >**Note**: You will be prompted to provide an Admin password.
 
    ```powershell
    $RGName = "IntLB-RG"
@@ -272,6 +273,8 @@ In this section, you will create a test VM, and then test the load balancer.
 
 1. If you select the refresh button in the browser a few times, you will see that the response comes randomly from the different VMs in the backend pool of the internal load balancer.
     ![Picture 9](../media/load-balancer-web-test-2.png)
+
+Congratulations! You have created and configured an Azure Load Balancer!
 
 ## Clean up resources
 

--- a/Instructions/Exercises/M04-Unit 6 Create a Traffic Manager profile using the Azure portal.md
+++ b/Instructions/Exercises/M04-Unit 6 Create a Traffic Manager profile using the Azure portal.md
@@ -171,6 +171,8 @@ In this section, you will check the DNS name of your Traffic Manager profile, an
 
 1. Verify that the web app is still responding. As the primary endpoint was not available, the traffic was instead routed to the failover endpoint to allow the web site to still function.
 
+Congratulations! You have created and configured an Azure Traffic Manager profile!
+
 ## Task 5: Clean up resources
 
    >**Note**: Remember to remove any newly created Azure resources that you no longer use. Removing unused resources ensures you will not see unexpected charges.

--- a/Instructions/Exercises/M04-Unit 6 Create a Traffic Manager profile using the Azure portal.md
+++ b/Instructions/Exercises/M04-Unit 6 Create a Traffic Manager profile using the Azure portal.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 04 - Load balancing non-HTTP(S) traffic in Azure'
 ---
 
-# M04-Unit 6 Create a Traffic Manager profile using the Azure portal
+# M04 - Unit 6 Create a Traffic Manager profile using the Azure portal
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M05-Unit 4 Deploy Azure application gateway.md
+++ b/Instructions/Exercises/M05-Unit 4 Deploy Azure application gateway.md
@@ -12,7 +12,6 @@ In this exercise, you use the Azure portal to create an application gateway. The
 
 ![Diagram of application gateway architecture.](../media/4-exercise-deploy-azure-application-gateway.png)
 
-
 >**Note**: An **[interactive lab simulation](https://mslabs.cloudguides.com/guides/AZ-700%20Lab%20Simulation%20-%20Deploy%20Azure%20Application%20Gateway)** is available that allows you to click through this lab at your own pace. You may find slight differences between the interactive simulation and the hosted lab, but the core concepts and ideas being demonstrated are the same.
 
 ### Estimated time: 25 minutes
@@ -60,8 +59,7 @@ In this exercise, you will:
    | Subnet name       | BackendSubnet                      |
    | Address range     | 10.0.1.0/24                        |
 
-
->**Note**: If the UI does not have the option to add additional subnets, complete the steps and add the backend subnet after creating the gateway. 
+    >**Note**: If the UI does not have the option to add additional subnets, complete the steps and add the backend subnet after creating the gateway.
 
 1. Select **OK** to return to the Create application gateway Basics tab.
 
@@ -135,12 +133,14 @@ It may take several minutes for Azure to create the application gateway. Wait un
 ## Task 2: Create virtual machines
 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
- > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
+
+    > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
+
 1. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **backend.json** and **backend.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M05**.
 
 1. Deploy the following ARM templates to create the VMs needed for this exercise:
 
->**Note**: You will be prompted to provide an Admin password.
+    >**Note**: You will be prompted to provide an Admin password.
 
    ```powershell
    $RGName = "ContosoResourceGroup"

--- a/Instructions/Exercises/M05-Unit 4 Deploy Azure application gateway.md
+++ b/Instructions/Exercises/M05-Unit 4 Deploy Azure application gateway.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 05 - Load balancing HTTP(S) traffic in Azure'
 ---
 
-# M05-Unit 4 Deploy Azure Application Gateway
+# M05 - Unit 4 Deploy Azure Application Gateway
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M05-Unit 6 Create a front door for a highly available web application using the Azure portal.md
+++ b/Instructions/Exercises/M05-Unit 6 Create a front door for a highly available web application using the Azure portal.md
@@ -4,8 +4,6 @@ Exercise:
     module: 'Module 05 - Load balancing HTTP(S) traffic in Azure'
 ---
 
-
-
 # M05-Unit 6 Create a Front Door for a highly available web application using the Azure portal
 
 ## Exercise scenario  
@@ -50,7 +48,7 @@ This exercise requires two instances of a web application that run in different 
    | Princing Plan    | Select **Standard S1 100 total ACU, 1.75 GB memory**.        |
 
 1. Select **Review + create**, review the Summary, and then select **Create**.
-   ‎It might take several minutes for the deployment to complete.
+   It might take several minutes for the deployment to complete.
 
 1. Create a second web app. On the Azure Portal home page, search  **WebApp**.
 
@@ -71,7 +69,7 @@ This exercise requires two instances of a web application that run in different 
    | Pricing Plan     | Select **Standard S1 100 total ACU, 1.75 GB memory**.        |
 
 1. Select **Review + create**, review the Summary, and then select **Create**.
-   ‎It might take several minutes for the deployment to complete.
+   It might take several minutes for the deployment to complete.
 
 ## Task 2: Create a Front Door for your application
 
@@ -127,11 +125,11 @@ Once you create a Front Door, it takes a few minutes for the configuration to be
 
    ![Browser showing App Service error page](../media/web-apps-both-stopped.png)
 
-   Congratulations! You have configured and tested an Azure Front Door.
+Congratulations! You have configured and tested an Azure Front Door.
 
 ## Task 4: Clean up resources
 
-   >**Note**: Remember to remove any newly created Azure resources that you no longer use. Removing unused resources ensures you will not see unexpected charges.
+>**Note**: Remember to remove any newly created Azure resources that you no longer use. Removing unused resources ensures you will not see unexpected charges.
 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
 

--- a/Instructions/Exercises/M05-Unit 6 Create a front door for a highly available web application using the Azure portal.md
+++ b/Instructions/Exercises/M05-Unit 6 Create a front door for a highly available web application using the Azure portal.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 05 - Load balancing HTTP(S) traffic in Azure'
 ---
 
-# M05-Unit 6 Create a Front Door for a highly available web application using the Azure portal
+# M05 - Unit 6 Create a Front Door for a highly available web application using the Azure portal
 
 ## Exercise scenario  
 

--- a/Instructions/Exercises/M06-Unit 4 Configure DDoS Protection on a virtual network using the Azure portal.md
+++ b/Instructions/Exercises/M06-Unit 4 Configure DDoS Protection on a virtual network using the Azure portal.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 06 - Design and implement network security'
 ---
 
-# M06-Unit 4 Configure DDoS Protection on a virtual network using the Azure portal
+# M06 - Unit 4 Configure DDoS Protection on a virtual network using the Azure portal
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M06-Unit 4 Configure DDoS Protection on a virtual network using the Azure portal.md
+++ b/Instructions/Exercises/M06-Unit 4 Configure DDoS Protection on a virtual network using the Azure portal.md
@@ -155,7 +155,7 @@ In this step you will create a virtual machine, assign a public IP address to it
    | Region                | Your region                                                  |
    | Availability options  | **No infrastructure  redundancy required**                   |
    | Image                 | **Ubuntu Server 20.04 LTS -  Gen 2** (Select Configure VM Generation link if needed) |
-   | Size                  | Select **See  all sizes**, then choose **B1ls** in the  list and choose **Select**  **(Standard_B1ls - 1 vcpu,  0.5 GiB memory** |
+   | Size                  | Select **See  all sizes**, then choose **B1ls** in the  list and choose **Select** **Standard_B1ls - 1 vcpu,  0.5 GiB memory** |
    | Authentication type   | **SSH public key**                                           |
    | Username              | **azureuser**                                                |
    | SSH public key source | **Generate new key pair**                                    |

--- a/Instructions/Exercises/M06-Unit 7 Deploy and configure Azure Firewall using the Azure portal.md
+++ b/Instructions/Exercises/M06-Unit 7 Deploy and configure Azure Firewall using the Azure portal.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 06 - Design and implement network security '
 ---
 
-# M06-Unit 7 Deploy and configure Azure Firewall using the Azure portal
+# M06 - Unit 7 Deploy and configure Azure Firewall using the Azure portal
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M06-Unit 7 Deploy and configure Azure Firewall using the Azure portal.md
+++ b/Instructions/Exercises/M06-Unit 7 Deploy and configure Azure Firewall using the Azure portal.md
@@ -297,7 +297,7 @@ In this task, you will add a DNAT rule that allows you to connect a remote deskt
    | Translated address    | Enter the private IP address from **Srv-Work** that you noted earlier.<br />**e.g. - 10.0.2.4** |
    | Translated port       | **3389**                                                     |
 
-​  ![Add a DNAT rule collection](../media/add-a-dnat-rule.png)
+   ​ ![Add a DNAT rule collection](../media/add-a-dnat-rule.png)
 
 1. Select **Add**.
 

--- a/Instructions/Exercises/M06-Unit 9 Secure your virtual hub using Azure Firewall Manager.md
+++ b/Instructions/Exercises/M06-Unit 9 Secure your virtual hub using Azure Firewall Manager.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 06 - Design and implement network security'
 ---
 
-# M06-Unit 9 Secure your virtual hub using Azure Firewall Manager
+# M06 - Unit 9 Secure your virtual hub using Azure Firewall Manager
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M06-Unit 9 Secure your virtual hub using Azure Firewall Manager.md
+++ b/Instructions/Exercises/M06-Unit 9 Secure your virtual hub using Azure Firewall Manager.md
@@ -4,7 +4,6 @@ Exercise:
     module: 'Module 06 - Design and implement network security'
 ---
 
-
 # M06-Unit 9 Secure your virtual hub using Azure Firewall Manager
 
 ## Exercise scenario
@@ -12,7 +11,6 @@ Exercise:
 In this exercise, you will create the spoke virtual network and create a secured virtual hub, then you will connect the hub and spoke virtual networks and route traffic to your hub. Next you will deploy the workload servers, then create a firewall policy and secure your hub, and finally you will test the firewall.
 
 ![Diagram of virtual network architecture with a secure hub.](../media/9-exercise-secure-your-virtual-hub-using-azure-firewall-manager.png)
-
 
 **Note:** An **[interactive lab simulation](https://mslabs.cloudguides.com/guides/AZ-700%20Lab%20Simulation%20-%20Secure%20your%20virtual%20hub%20using%20Azure%20Firewall%20Manager)** is available that allows you to click through this lab at your own pace. You may find slight differences between the interactive simulation and the hosted lab, but the core concepts and ideas being demonstrated are the same.
 
@@ -40,19 +38,32 @@ In this exercise, you will:
 In this task, you will create the two spoke virtual networks each containing a subnet that will host your workload servers.
 
 1. On the Azure portal home page, in the search box, enter **virtual network** and select **Virtual Network** when it appears.
-2. Select **Create**.
-3. In **Resource group**, select **Create new**, and enter **fw-manager-rg** as the name and select **OK**.
-4. In **Name**, enter **Spoke-01**.
-5. In **Region**, select your region.
-6. Select **Next: IP Addresses**.
-7. In **IPv4 address space**, enter **10.0.0.0/16**.
-8. **Delete** any other address spaces listed here, such as **10.1.0.0/16**.
-9. Under **Subnet name**, select the word **default**.
-10. In the **Edit subnet** dialog box, change the name to **Workload-01-SN**.
-11. Change the **Subnet address range** to **10.0.1.0/24**.
-12. Select **Save**.
-13. Select **Review + create**.
-14. Select **Create**.
+
+1. Select **Create**.
+
+1. In **Resource group**, select **Create new**, and enter **fw-manager-rg** as the name and select **OK**.
+
+1. In **Name**, enter **Spoke-01**.
+
+1. In **Region**, select your region.
+
+1. Select **Next: IP Addresses**.
+
+1. In **IPv4 address space**, enter **10.0.0.0/16**.
+
+1. **Delete** any other address spaces listed here, such as **10.1.0.0/16**.
+
+1. Under **Subnet name**, select the word **default**.
+
+1. In the **Edit subnet** dialog box, change the name to **Workload-01-SN**.
+
+1. Change the **Subnet address range** to **10.0.1.0/24**.
+
+1. Select **Save**.
+
+1. Select **Review + create**.
+
+1. Select **Create**.
 
 Repeat steps 1 to 14 above to create another similar virtual network and subnet but using the following information:
 
@@ -68,70 +79,78 @@ In this task you will create your secured virtual hub using Firewall Manager.
 
 1. From the Azure portal home page, select **All services**.
 
-2. In the search box, enter **firewall manager** and select **Firewall Manager** when it appears.
+1. In the search box, enter **firewall manager** and select **Firewall Manager** when it appears.
 
-3. On the **Firewall Manager** page, from the Overview page, select **View secured virtual hubs**.
+1. On the **Firewall Manager** page, from the Overview page, select **View secured virtual hubs**.
 
-4. On the **Virtual hubs** page, select **Create new secured virtual hub**.
+1. On the **Virtual hubs** page, select **Create new secured virtual hub**.
 
-5. For **Resource group**, select **fw-manager-rg**.
+1. For **Resource group**, select **fw-manager-rg**.
 
-6. For **Region**, select your region.
+1. For **Region**, select your region.
 
-7. For the **Secured virtual hub name**, enter **Hub-01**.
+1. For the **Secured virtual hub name**, enter **Hub-01**.
 
-8. For **Hub address space**, enter **10.2.0.0/16**.
+1. For **Hub address space**, enter **10.2.0.0/16**.
 
-9. Choose **New vWAN**.
+1. Choose **New vWAN**.
 
-10. In **Virtual WAN Name**, enter **Vwan-01**.
+1. In **Virtual WAN Name**, enter **Vwan-01**.
 
-11. Select **Next: Azure Firewall**.
+1. Select **Next: Azure Firewall**.
     ![Create new secured virtual hub - Basics tab](../media/create-new-secured-virtual-hub-1.png)
 
-12. Select **Next: Security Partner Provider**.
+1. Select **Next: Security Partner Provider**.
 
-13. Select **Next: Review + create.**
+1. Select **Next: Review + create.**
 
-14. Select **Create**.
+1. Select **Create**.
 
     > **[!NOTE]**
     >
     > This can take up to 30 minutes to deploy.
 
-    ​
-
     ![Create new secured virtual hub - Review + create tab](../media/create-new-secured-virtual-hub-2.png)
 
-15. When the deployment completes, from the Azure portal home page, select **All services**.
+1. When the deployment completes, from the Azure portal home page, select **All services**.
 
-16. In the search box, enter **firewall manager** and select **Firewall Manager** when it appears.
+1. In the search box, enter **firewall manager** and select **Firewall Manager** when it appears.
 
-17. On the **Firewall Manager** page, select **Virtual hubs**.
+1. On the **Firewall Manager** page, select **Virtual hubs**.
 
-18. Select **Hub-01**.
+1. Select **Hub-01**.
 
-19. Select **Public IP configuration**.
+1. Select **Public IP configuration**.
 
-20. Note down the public IP address (e.g., **51.143.226.18**), which you will use later.
+1. Note down the public IP address (e.g., **51.143.226.18**), which you will use later.
 
 ## Task 3: Connect the hub and spoke virtual networks
 
 In this task you will connect the hub and spoke virtual networks. This is commonly known as peering.
 
 1. From the Azure portal home page, select **Resource groups**.
-2. Select the **fw-manager-rg** resource group, then select the **Vwan-01** virtual WAN.
-3. Under **Connectivity**, select **Virtual network connections**.
-4. Select **Add connection**.
-5. For **Connection name**, enter **hub-spoke-01**.
-6. For **Hubs**, select **Hub-01**.
-7. For **Resource group**, select **fw-manager-rg**.
-8. For **Virtual network**, select **Spoke-01**.
-9. Select **Create**.
-   ![Add hub and spoke connection to virtual WAN - Spoke 1](../media/connect-hub-spoke-vnet-1.png)
-10. Repeat steps 4 to 9 above to create another similar connection but using the connection name of **hub-spoke-02** to connect the **Spoke-02** virtual network.
 
-![Add hub and spoke connection to virtual WAN - Spoke 2](../media/connect-hub-spoke-vnet-2.png)
+1. Select the **fw-manager-rg** resource group, then select the **Vwan-01** virtual WAN.
+
+1. Under **Connectivity**, select **Virtual network connections**.
+
+1. Select **Add connection**.
+
+1. For **Connection name**, enter **hub-spoke-01**.
+
+1. For **Hubs**, select **Hub-01**.
+
+1. For **Resource group**, select **fw-manager-rg**.
+
+1. For **Virtual network**, select **Spoke-01**.
+
+1. Select **Create**.
+
+    ![Add hub and spoke connection to virtual WAN - Spoke 1](../media/connect-hub-spoke-vnet-1.png)
+
+1. Repeat steps 4 to 9 above to create another similar connection but using the connection name of **hub-spoke-02** to connect the **Spoke-02** virtual network.
+
+    ![Add hub and spoke connection to virtual WAN - Spoke 2](../media/connect-hub-spoke-vnet-2.png)
 
 ## Task 4: Deploy the servers
 
@@ -168,7 +187,7 @@ In this task you will first create your firewall policy, then secure your hub. T
 
 1. On **Resource group**, select **fw-manager-rg**.
 
-5. Under **Policy details**, for the **Name**, enter **Policy-01**.
+1. Under **Policy details**, for the **Name**, enter **Policy-01**.
 
 1. On **Region** select your region.
 

--- a/Instructions/Exercises/M07-Unit 5 Restrict network access to PaaS resources with virtual network service endpoints.md
+++ b/Instructions/Exercises/M07-Unit 5 Restrict network access to PaaS resources with virtual network service endpoints.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 07 - Design and implement private access to Azure Services'
 ---
 
-# M07-Unit 5 Restrict network access to PaaS resources with virtual network service endpoints
+# M07 - Unit 5 Restrict network access to PaaS resources with virtual network service endpoints
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M07-Unit 5 Restrict network access to PaaS resources with virtual network service endpoints.md
+++ b/Instructions/Exercises/M07-Unit 5 Restrict network access to PaaS resources with virtual network service endpoints.md
@@ -219,12 +219,12 @@ The steps necessary to restrict network access to resources created through Azur
 ## Task 7: Create a file share in the storage account
 
 1. After the storage account is created, enter the name of the storage account in the **Search resources, services, and docs** box, at the top of the portal. When the name of your storage account appears in the search results, select it.
-1. Select **File shares**, as shown in the following picture: 
+1. Select **File shares**, as shown in the following picture:
    ![Graphical user interface, application Description automatically generated](../media/new-file-share-2.png)
 1. Select **+ File share**.
 1. Enter marketing under **Name**, and then select **Next : Backup**.
    ![Graphical user interface, application Description automatically generated](../media/new-file-share-basics.png)
-1. Unselect **Enable backup**, as shown in the following picture: 
+1. Unselect **Enable backup**, as shown in the following picture:
    ![Graphical user interface, application Description automatically generated](../media/new-file-share-backup.png)
 1. Select **Review + Create**. Once the resource is validated select **Create**.
 
@@ -312,7 +312,7 @@ You receive no replies because the network security group associated to the Priv
 
 1. Complete steps 1-6 in the Confirm access to storage account task for the ContosoPublic VM.  
 
-   ‎After a short wait, you receive a New-PSDrive : Access is denied error. Access is denied because the ContosoPublic VM is deployed in the Public subnet. The Public subnet does not have a service endpoint enabled for Azure Storage. The storage account only allows network access from the Private subnet, not the Public subnet.
+   After a short wait, you receive a New-PSDrive : Access is denied error. Access is denied because the ContosoPublic VM is deployed in the Public subnet. The Public subnet does not have a service endpoint enabled for Azure Storage. The storage account only allows network access from the Private subnet, not the Public subnet.
 
 1. Confirm that the public VM does have outbound connectivity to the internet from a command prompt:
 
@@ -328,13 +328,13 @@ You receive no replies because the network security group associated to the Priv
 
 1. You receive the error shown in the following screenshot:
 
-    ![Graphical user interface, text, application, email Description automatically generated](../media/no-access.png)
+   ![Graphical user interface, text, application, email Description automatically generated](../media/no-access.png)
 
  Access is denied, because your computer is not in the Private subnet of the CoreServicesVNet virtual network.
 
 > **Warning**: Prior to continuing you should remove all resources used for this lab. To do this On the Azure portal select Resource groups. Select any resources groups you have created. On the resource group blade select Delete Resource group, enter the Resource Group Name and select Delete. Repeat the process for any additional Resource Groups you may have created. Failure to do this may cause issues with other labs.
 
-Results: You have now completed this lab.
+Congratulations! You have now completed the lab.
 
 ## Task 11: Clean up resources
 

--- a/Instructions/Exercises/M07-Unit 6 Create an Azure private endpoint using Azure PowerShell.md
+++ b/Instructions/Exercises/M07-Unit 6 Create an Azure private endpoint using Azure PowerShell.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 07 - Design and implement private access to Azure Services'
 ---
 
-# M07-Unit 6 Create an Azure private endpoint using Azure PowerShell
+# M07 - Unit 6 Create an Azure private endpoint using Azure PowerShell
 
 ## Exercise scenario
 

--- a/Instructions/Exercises/M07-Unit 6 Create an Azure private endpoint using Azure PowerShell.md
+++ b/Instructions/Exercises/M07-Unit 6 Create an Azure private endpoint using Azure PowerShell.md
@@ -12,7 +12,6 @@ Get started with Azure Private Link by using a Private Endpoint to connect secur
 
 ![Diagram of private endpoint architecture.](../media/6-exercise-create-azure-private-endpoint-using-azure-powershell.png)
 
-
 **Note:** An **[interactive lab simulation](https://mslabs.cloudguides.com/guides/AZ-700%20Lab%20Simulation%20-%20Create%20an%20Azure%20private%20endpoint%20using%20Azure%20PowerShell)** is available that allows you to click through this lab at your own pace. You may find slight differences between the interactive simulation and the hosted lab, but the core concepts and ideas being demonstrated are the same.
 
 ### Estimated time: 45 minutes
@@ -21,7 +20,7 @@ You'll create a Private Endpoint for an Azure web app and deploy a virtual machi
 
 Private Endpoints can be created for different kinds of Azure services, such as Azure SQL and Azure Storage.
 
-**Prerequisites**
+## Prerequisites
 
 - An Azure Web App with a PremiumV2-tier or higher app service plan deployed in your Azure subscription.
 
@@ -57,11 +56,11 @@ New-AzResourceGroup -Name 'CreatePrivateEndpointQS-rg' -Location 'eastus'
 
 Deploy the following ARM templates to create the PremiumV2-tier Azure Web App needed for this exercise:
 
-   ```powershell
-   $RGName = "CreatePrivateEndpointQS-rg"
-   
-   New-AzResourceGroupDeployment -ResourceGroupName $RGName -TemplateFile template.json -TemplateParameterFile parameters.json
-   ```
+  ```powershell
+  $RGName = "CreatePrivateEndpointQS-rg"
+
+  New-AzResourceGroupDeployment -ResourceGroupName $RGName -TemplateFile template.json -TemplateParameterFile parameters.json
+  ```
 
 If you receive an error (for example while looking into the Deployment status in the Portal) like "Website with given name GEN-UNIQUE already exists." please make sure to go to the Prerequisites mentioned above regarding editing the template.
 
@@ -381,28 +380,28 @@ In this section, you'll use the virtual machine you created in the previous step
 
 1. Open Windows PowerShell on the server after you connect.
 
-1. Enter nslookup &lt;your- webapp-name&gt;.azurewebsites.net. Replace &lt;your-webapp-name&gt; with the name of the web app you created in the previous steps. You'll receive a message similar to what is displayed below:
+1. Enter nslookup **&lt;your- webapp-name&gt;.azurewebsites.net**. Replace **&lt;your-webapp-name&gt;** with the name of the web app you created in the previous steps. You'll receive a message similar to what is displayed below:
 
-  ```
-  Server: UnKnown
-  
-  Address: 168.63.129.16
-  
-  Non-authoritative answer:
-  
-  Name: mywebapp8675.privatelink.azurewebsites.net
-  
-  Address: 10.0.0.5
-  
-  Aliases: mywebapp8675.azurewebsites.net 
-  ```  
+   ```
+   Server: UnKnown
+   
+   Address: 168.63.129.16
+   
+   Non-authoritative answer:
+   
+   Name: mywebapp8675.privatelink.azurewebsites.net
+   
+   Address: 10.0.0.5
+   
+   Aliases: mywebapp8675.azurewebsites.net 
+   ```
 
-A private IP address of **10.0.0.5** is returned for the web app name. This address is in the subnet of the virtual network you created previously.
+   A private IP address of **10.0.0.5** is returned for the web app name. This address is in the subnet of the virtual network you created previously.
 
 1. In the bastion connection to **myVM**, open Internet Explorer.
 1. Enter the url of your web app, **https://&lt;your-webapp-name&gt;.azurewebsites.net**
 1. You'll receive the default web app page if your application hasn't been deployed:
-  ![screen shot of page in Azure indicating an app service is up and running](../media/web-app-default-page.png)
+![screen shot of page in Azure indicating an app service is up and running](../media/web-app-default-page.png)
 1. Close the connection to **myVM**.
 
 ## Task 7: Clean up resources

--- a/Instructions/Exercises/M08-Unit 3 Monitor a load balancer resource using Azure Monitor.md
+++ b/Instructions/Exercises/M08-Unit 3 Monitor a load balancer resource using Azure Monitor.md
@@ -182,7 +182,7 @@ In this section, you will create three VMs for the backend pool of the load bala
 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
 
- > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
+   > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
 
 1. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **azuredeploy.json** and **azuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M08**.
 
@@ -196,7 +196,7 @@ In this section, you will create three VMs for the backend pool of the load bala
    New-AzResourceGroupDeployment -ResourceGroupName $RGName -TemplateFile azuredeploy.json -TemplateParameterFile azuredeploy.parameters.json
    ```
   
-    > **Note:** This will take several minutes to deploy.
+   > **Note:** This will take several minutes to deploy.
 
 ## Task 7: Add VMs to the backend pool
 
@@ -408,4 +408,4 @@ In this section, you will create a test VM, and then test the load balancer.
    Remove-AzResourceGroup -Name 'IntLB-RG' -Force -AsJob
    ```
 
-    >**Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.
+   >**Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.

--- a/Instructions/Exercises/M08-Unit 3 Monitor a load balancer resource using Azure Monitor.md
+++ b/Instructions/Exercises/M08-Unit 3 Monitor a load balancer resource using Azure Monitor.md
@@ -4,7 +4,7 @@ Exercise:
     module: 'Module 08 - Design and implement network monitoring'
 ---
 
-# M08-Unit 3 Monitor a load balancer resource using Azure Monitor
+# M08 - Unit 3 Monitor a load balancer resource using Azure Monitor
 
 ## Exercise scenario
 


### PR DESCRIPTION
# Module: 01

Noted throughout below units, there are a number of instances where the Pipe character "|" results in a markdown formatting error in Github.io pages. Have converted references to instead use the HTML delimited character code.

Fixes:
- Unit 4 
- Unit 6
- Unit 8

Changes proposed in this pull request:

- Minor updates to formatting and capitalization in Module 1, Unit 4
- Fix in formatting that results in github.io formatting error in instructions in Module 1, Unit 6
- Minor updates to formatting and capitalization in Module 1, Unit 8

### Relevant Screenshot(s)
![Screenshot 2024-08-19 151435](https://github.com/user-attachments/assets/bfa61bb1-fa2e-4352-b3f9-cbd3cf77f240)
