### PR TITLE
Module 01 - Formatting Uplift and Issues due to use of Pipe character

### DIFF
--- a/Instructions/Exercises/M01-Unit 4 Design and implement a Virtual Network in Azure.md
+++ b/Instructions/Exercises/M01-Unit 4 Design and implement a Virtual Network in Azure.md
@@ -3,7 +3,8 @@ Exercise:
     title: 'M01 - Unit 4 Design and implement a Virtual Network in Azure'
     module: 'Module 01 - Introduction to Azure Virtual Networks'
 ---
-# M01-Unit 4 Design and implement a Virtual Network in Azure
+
+# M01 - Unit 4 Design and implement a Virtual Network in Azure
 
 ## Exercise scenario
 
@@ -59,104 +60,105 @@ In this exercise, you will:
 
 1. Go to [Azure portal](https://portal.azure.com/).
 
-2. On the home page, under **Azure services**, select **Resource groups**.  
+1. On the home page, under **Azure services**, select **Resource groups**.  
 
-3. In the Resource groups, select **+ Create**.
+1. In the Resource groups, select **+ Create**.
 
-4. Use the information in the following table to create the resource group.
+1. Use the information in the following table to create the resource group.
 
-| **Tab**         | **Option**                                 | **Value**            |
-| --------------- | ------------------------------------------ | -------------------- |
-| Basics          | Resource group                             | ContosoResourceGroup |
-|                 | Region                                     | (US) East US         |
-| Tags            | No changes required                        |                      |
-| Review + create | Review your settings and select **Create** |                      |
+   | **Tab**         | **Option**                                 | **Value**            |
+   | --------------- | ------------------------------------------ | -------------------- |
+   | Basics          | Resource group                             | ContosoResourceGroup |
+   |                 | Region                                     | (US) East US         |
+   | Tags            | No changes required                        |                      |
+   | Review + create | Review your settings and select **Create** |                      |
 
-5. In Resource groups, verify that **ContosoResourceGroup** appears in the list.
+1. In Resource groups, verify that **ContosoResourceGroup** appears in the list.
 
 ## Task 2: Create the CoreServicesVnet virtual network and subnets
 
 1. On the Azure portal home page, navigate to the Global Search bar and search **Virtual Networks** and select virtual networks under services.  ![Azure portal home page Global Search bar results for virtual network.](../media/global-search-bar.PNG)
-2. Select **Create** on the Virtual networks page.  ![Create a virtual network wizard.](../media/create-virtual-network.png)
-3. Use the information in the following table to create the CoreServicesVnet virtual network.  
-   ‎Remove or overwrite the default IP Address space![ip address configuration for azure virtual network deployment ](../media/default-vnet-ip-address-range-annotated.png)
 
-| **Tab**      | **Option**         | **Value**            |
-| ------------ | ------------------ | -------------------- |
-| Basics       | Resource Group     | ContosoResourceGroup |
-|              | Name               | CoreServicesVnet     |
-|              | Region             | (US) East US         |
-| IP Addresses | IPv4 address space | 10.20.0.0/16         |
+1. Select **Create** on the Virtual networks page.  ![Create a virtual network wizard.](../media/create-virtual-network.png)
+1. Use the information in the following table to create the CoreServicesVnet virtual network.  
+   Remove or overwrite the default IP Address space. ![IP address configuration for Azure virtual network deployment ](../media/default-vnet-ip-address-range-annotated.png)
 
- 4. Use the information in the following table to create the CoreServicesVnet subnets.
+   | **Tab**      | **Option**         | **Value**            |
+   | ------------ | ------------------ | -------------------- |
+   | Basics       | Resource Group     | ContosoResourceGroup |
+   |              | Name               | CoreServicesVnet     |
+   |              | Region             | (US) East US         |
+   | IP Addresses | IPv4 address space | 10.20.0.0/16         |
 
- 5. To begin creating each subnet, select **+ Add subnet**. To finish creating each subnet, select **Add**.
+1. Use the information in the following table to create the CoreServicesVnet subnets.
 
-| **Subnet**             | **Option**           | **Value**              |
-| ---------------------- | -------------------- | ---------------------- |
-| GatewaySubnet          | Subnet name          | GatewaySubnet          |
-|                        | Subnet address range | 10.20.0.0/27           |
-| SharedServicesSubnet   | Subnet name          | SharedServicesSubnet   |
-|                        | Subnet address range | 10.20.10.0/24          |
-| DatabaseSubnet         | Subnet name          | DatabaseSubnet         |
-|                        | Subnet address range | 10.20.20.0/24          |
-| PublicWebServiceSubnet | Subnet name          | PublicWebServiceSubnet |
-|                        | Subnet address range | 10.20.30.0/24          |
+1. To begin creating each subnet, select **+ Add subnet**. To finish creating each subnet, select **Add**.
 
- 6. To finish creating the CoreServicesVnet and its associated subnets, select **Review + create**.
+   | **Subnet**             | **Option**           | **Value**              |
+   | ---------------------- | -------------------- | ---------------------- |
+   | GatewaySubnet          | Subnet name          | GatewaySubnet          |
+   |                        | Subnet address range | 10.20.0.0/27           |
+   | SharedServicesSubnet   | Subnet name          | SharedServicesSubnet   |
+   |                        | Subnet address range | 10.20.10.0/24          |
+   | DatabaseSubnet         | Subnet name          | DatabaseSubnet         |
+   |                        | Subnet address range | 10.20.20.0/24          |
+   | PublicWebServiceSubnet | Subnet name          | PublicWebServiceSubnet |
+   |                        | Subnet address range | 10.20.30.0/24          |
 
- 7. Verify your configuration passed validation, and then select **Create**.
+1. To finish creating the CoreServicesVnet and its associated subnets, select **Review + create**.
 
- 8. Repeat steps 1 -8 for each VNet based on the tables below  
+1. Verify your configuration passed validation, and then select **Create**.
+
+1. Repeat steps 1 -8 for each VNet based on the tables below  
 
 ## Task 3: Create the ManufacturingVnet virtual network and subnets
 
-| **Tab**      | **Option**         | **Value**            |
-| ------------ | ------------------ | -------------------- |
-| Basics       | Resource Group     | ContosoResourceGroup |
-|              | Name               | ManufacturingVnet    |
-|              | Region             | (Europe) West Europe |
-| IP Addresses | IPv4 address space | 10.30.0.0/16         |
+   | **Tab**      | **Option**         | **Value**            |
+   | ------------ | ------------------ | -------------------- |
+   | Basics       | Resource Group     | ContosoResourceGroup |
+   |              | Name               | ManufacturingVnet    |
+   |              | Region             | (Europe) West Europe |
+   | IP Addresses | IPv4 address space | 10.30.0.0/16         |
 
-| **Subnet**                | **Option**           | **Value**                 |
-| ------------------------- | -------------------- | ------------------------- |
-| ManufacturingSystemSubnet | Subnet name          | ManufacturingSystemSubnet |
-|                           | Subnet address range | 10.30.10.0/24             |
-| SensorSubnet1             | Subnet name          | SensorSubnet1             |
-|                           | Subnet address range | 10.30.20.0/24             |
-| SensorSubnet2             | Subnet name          | SensorSubnet2             |
-|                           | Subnet address range | 10.30.21.0/24             |
-| SensorSubnet3             | Subnet name          | SensorSubnet3             |
-|                           | Subnet address range | 10.30.22.0/24             |
+   | **Subnet**                | **Option**           | **Value**                 |
+   | ------------------------- | -------------------- | ------------------------- |
+   | ManufacturingSystemSubnet | Subnet name          | ManufacturingSystemSubnet |
+   |                           | Subnet address range | 10.30.10.0/24             |
+   | SensorSubnet1             | Subnet name          | SensorSubnet1             |
+   |                           | Subnet address range | 10.30.20.0/24             |
+   | SensorSubnet2             | Subnet name          | SensorSubnet2             |
+   |                           | Subnet address range | 10.30.21.0/24             |
+   | SensorSubnet3             | Subnet name          | SensorSubnet3             |
+   |                           | Subnet address range | 10.30.22.0/24             |
 
 ## Task 4: Create the ResearchVnet virtual network and subnets
 
-| **Tab**      | **Option**         | **Value**            |
-| ------------ | ------------------ | -------------------- |
-| Basics       | Resource Group     | ContosoResourceGroup |
-|              | Name               | ResearchVnet         |
-|              | Region             | Southeast Asia       |
-| IP Addresses | IPv4 address space | 10.40.0.0/16         |
+   | **Tab**      | **Option**         | **Value**            |
+   | ------------ | ------------------ | -------------------- |
+   | Basics       | Resource Group     | ContosoResourceGroup |
+   |              | Name               | ResearchVnet         |
+   |              | Region             | Southeast Asia       |
+   | IP Addresses | IPv4 address space | 10.40.0.0/16         |
 
-| **Subnet**           | **Option**           | **Value**            |
-| -------------------- | -------------------- | -------------------- |
-| ResearchSystemSubnet | Subnet name          | ResearchSystemSubnet |
-|                      | Subnet address range | 10.40.0.0/24         |
+   | **Subnet**           | **Option**           | **Value**            |
+   | -------------------- | -------------------- | -------------------- |
+   | ResearchSystemSubnet | Subnet name          | ResearchSystemSubnet |
+   |                      | Subnet address range | 10.40.0.0/24         |
 
 ## Task 5: Verify the creation of VNets and Subnets
 
 1. On the Azure portal home page, select **All resources**.
 
-2. Verify that the CoreServicesVnet, ManufacturingVnet, and ResearchVnet are listed.
+1. Verify that the CoreServicesVnet, ManufacturingVnet, and ResearchVnet are listed.
 
-3. Select **CoreServicesVnet**.
+1. Select **CoreServicesVnet**.
 
-4. In CoreServicesVnet, under **Settings**, select **Subnets**.
+1. In CoreServicesVnet, under **Settings**, select **Subnets**.
 
-5. In CoreServicesVnet | Subnets, verify that the subnets you created are listed, and that the IP address ranges are correct.
+1. In CoreServicesVnet \| Subnets, verify that the subnets you created are listed, and that the IP address ranges are correct.
 
    ![List of subnets in CoreServicesVnet.](../media/verify-subnets-annotated.png)
 
-6. Repeat steps 3 - 5 for each VNet.
+1. Repeat steps 3 - 5 for each VNet.
 
 Congratulations! You have successfully created a resource group, three VNets, and their associated subnets.

--- a/Instructions/Exercises/M01-Unit 6 Configure DNS settings in Azure.md
+++ b/Instructions/Exercises/M01-Unit 6 Configure DNS settings in Azure.md
@@ -27,73 +27,73 @@ In this exercise, you will:
 
 1. Go to [Azure Portal](https://portal.azure.com/).
 
-2. On the Azure home page, in the search bar, enter dns, and then select **Private DNS zones**.  
-   ‎![Azure Portal home page with dns search.](../media/create-private-dns-zone.png)
+1. On the Azure home page, in the search bar, enter dns, and then select **Private DNS zones**.  
+   ![Azure Portal home page with DNS search.](../media/create-private-dns-zone.png)
 
-3. In Private DNS zones, select **+ Create**.
+1. In Private DNS zones, select **+ Create**.
 
-4. Use the information in the following table to create the private DNS zone.
+1. Use the information in the following table to create the private DNS zone.
 
-| **Tab**         | **Option**                             | **Value**            |
-| --------------- | -------------------------------------- | -------------------- |
-| Basics          | Resource group                         | ContosoResourceGroup |
-|                 | Name                                   | Contoso.com          |
-| Tags            | No changes required                    |                      |
-| Review + create | Review your settings and select Create |                      |
+    | **Tab**         | **Option**                             | **Value**            |
+    | --------------- | -------------------------------------- | -------------------- |
+    | Basics          | Resource group                         | ContosoResourceGroup |
+    |                 | Name                                   | Contoso.com          |
+    | Tags            | No changes required                    |                      |
+    | Review + create | Review your settings and select Create |                      |
 
-5. Wait until the deployment is complete, and then select **Go to resource**.
+1. Wait until the deployment is complete, and then select **Go to resource**.
 
-6. Verify that the zone has been created.
+1. Verify that the zone has been created.
 
 ## Task 2: Link subnet for auto registration
 
 1. In Contoso.com, under **Settings**, select **Virtual network links**.
 
-2. On Contoso.com | Virtual network links, select **+ Add**.
+1. On Contoso.com \| Virtual network links, select **+ Add**.
 
-![contoso.com | Virtual links with + Add highlighted.](../media/add-network-link-dns.png)
+    ![contoso.com \| Virtual links with + Add highlighted.](../media/add-network-link-dns.png)
 
-3. Use the information in the following table to add the virtual network link.
+1. Use the information in the following table to add the virtual network link.
 
-| **Option**                          | **Value**                               |
-| ----------------------------------- | --------------------------------------- |
-| Link name                           | CoreServicesVnetLink                    |
-| Subscription                        | No changes required                     |
-| Virtual Network                     | CoreServicesVnet (ContosoResourceGroup) |
-| Enable auto registration            | Selected                                |
-| Review your settings and select OK. |                                         |
+    | **Option**                          | **Value**                               |
+    | ----------------------------------- | --------------------------------------- |
+    | Link name                           | CoreServicesVnetLink                    |
+    | Subscription                        | No changes required                     |
+    | Virtual Network                     | CoreServicesVnet (ContosoResourceGroup) |
+    | Enable auto registration            | Selected                                |
+    | Review your settings and select OK. |                                         |
 
-4. Select **Refresh**.
+1. Select **Refresh**.
 
-5. Verify that the CoreServicesVnetLink has been created, and that auto-registration is enabled.
+1. Verify that the CoreServicesVnetLink has been created, and that auto-registration is enabled.
 
-6. Repeat steps 2 - 5 for the ManufacturingVnet, using the information in the following table:
+1. Repeat steps 2 - 5 for the ManufacturingVnet, using the information in the following table:
 
-| **Option**                          | **Value**                                |
-| ----------------------------------- | ---------------------------------------- |
-| Link name                           | ManufacturingVnetLink                    |
-| Subscription                        | No changes required                      |
-| Virtual Network                     | ManufacturingVnet (ContosoResourceGroup) |
-| Enable auto registration            | Selected                                 |
-| Review your settings and select OK. |                                          |
+    | **Option**                          | **Value**                                |
+    | ----------------------------------- | ---------------------------------------- |
+    | Link name                           | ManufacturingVnetLink                    |
+    | Subscription                        | No changes required                      |
+    | Virtual Network                     | ManufacturingVnet (ContosoResourceGroup) |
+    | Enable auto registration            | Selected                                 |
+    | Review your settings and select OK. |                                          |
 
-7. Select **Refresh**.
+1. Select **Refresh**.
 
-8. Verify that the ManufacturingVnetLink has been created, and that auto-registration is enabled.
+1. Verify that the ManufacturingVnetLink has been created, and that auto-registration is enabled.
 
-9. Repeat steps 2 - 5 for the ResearchVnet, using the information in the following table:
+1. Repeat steps 2 - 5 for the ResearchVnet, using the information in the following table:
 
-| **Option**                          | **Value**                           |
-| ----------------------------------- | ----------------------------------- |
-| Link name                           | ResearchVnetLink                    |
-| Subscription                        | No changes required                 |
-| Virtual Network                     | ResearchVnet (ContosoResourceGroup) |
-| Enable auto registration            | Selected                            |
-| Review your settings and select OK. |                                     |
+    | **Option**                          | **Value**                           |
+    | ----------------------------------- | ----------------------------------- |
+    | Link name                           | ResearchVnetLink                    |
+    | Subscription                        | No changes required                 |
+    | Virtual Network                     | ResearchVnet (ContosoResourceGroup) |
+    | Enable auto registration            | Selected                            |
+    | Review your settings and select OK. |                                     |
 
-10. Select **Refresh**.
+1. Select **Refresh**.
 
-11. Verify that the ResearchVnetLink has been created, and that auto-registration is enabled.
+1. Verify that the ResearchVnetLink has been created, and that auto-registration is enabled.
 
 ## Task 3: Create Virtual Machines to test the configuration
 
@@ -103,9 +103,9 @@ In this section, you will create two test VMs to test the Private DNS zone confi
 
     > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
 
-2. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **azuredeploy.json** and **azuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M01**.
+1. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **azuredeploy.json** and **azuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M01**.
 
-3. Deploy the following ARM templates to create the VMs needed for this exercise:
+1. Deploy the following ARM templates to create the VMs needed for this exercise:
 
     >**Note**: You will be prompted to provide an Admin password.
 
@@ -115,21 +115,21 @@ In this section, you will create two test VMs to test the Private DNS zone confi
    New-AzResourceGroupDeployment -ResourceGroupName $RGName -TemplateFile azuredeploy.json -TemplateParameterFile azuredeploy.parameters.json
    ```
   
-4. When the deployment is complete, go to the Azure portal home page, and then select **Virtual Machines**.
+1. When the deployment is complete, go to the Azure portal home page, and then select **Virtual Machines**.
 
-5. Verify that both virtual machines have been created.
+1. Verify that both virtual machines have been created.
 
 ## Task 4: Verify records are present in the DNS zone
 
 1. On the Azure Portal home page, select **Private DNS zones**.
 
-2. On Private DNS zones, select **contoso.com**.
+1. On Private DNS zones, select **contoso.com**.
 
-3. Verify that host (A) records are listed for both VMs, as shown:
+1. Verify that host (A) records are listed for both VMs, as shown:
 
-![Contoso.com DNS zone showing auto-registered host A records.](../media/contoso_com-dns-zone.png)
+    ![Contoso.com DNS zone showing auto-registered host A records.](../media/contoso_com-dns-zone.png)
 
-4. Make a note of the names and IP addresses of the VMs.
+1. Make a note of the names and IP addresses of the VMs.
 
 ### Connect to the Test VMs using RDP
 
@@ -153,7 +153,7 @@ In this section, you will create two test VMs to test the Private DNS zone confi
 
 1. On both VMs, if prompted, in **Networks**, select **Yes**.
 
-1. On TestVM1, open a command prompt and enter the command ipconfig /all.
+1. On TestVM1, open a command prompt and enter the command `ipconfig /all`.
 
 1. Verify that the IP address is the same as the one you noted in the DNS zone.
 

--- a/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
+++ b/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
@@ -3,7 +3,8 @@ Exercise:
     title: 'M01 - Unit 8 Connect two Azure Virtual Networks using global virtual network peering'
     module: 'Module 01 - Introduction to Azure Virtual Networks'
 ---
-# M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering
+
+# M01 - Unit 8 Connect two Azure Virtual Networks using global virtual network peering
 
 ## Exercise scenario
 
@@ -31,7 +32,7 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 ### Create ManufacturingVM
 
 1. On the Azure portal, open the **PowerShell** session within the **Cloud Shell** pane.
-  > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
+   > **Note:** If this is the first time opening Cloud Shell, you might be prompted to create a storage account. Select **Create storage**.
 
 1. On the toolbar of the Cloud Shell pane, select the **Upload/Download files** icon, in the drop-down menu, select **Upload** and upload the following files **ManufacturingVMazuredeploy.json** and **ManufacturingVMazuredeploy.parameters.json** into the Cloud Shell home directory one by one from the source folder **F:\Allfiles\Exercises\M01**.
 
@@ -57,7 +58,7 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 
 1. On ManufacturingVM, select **Connect &gt; RDP**.
 
-1. On ManufacturingVM | Connect, select **Download RDP file**.
+1. On ManufacturingVM \| Connect, select **Download RDP file**.
 
 1. Save the RDP file to your desktop.
 
@@ -69,7 +70,7 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 
 1. On TestVM1, select **Connect &gt; RDP**.
 
-1. On TestVM1 | Connect, select **Download RDP file**.
+1. On TestVM1 \| Connect, select **Download RDP file**.
 
 1. Save the RDP file to your desktop.
 
@@ -101,34 +102,34 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 1. On the Azure home page, select **Virtual Networks**, and then select **CoreServicesVnet**.
 
 1. In CoreServicesVnet, under **Settings**, select **Peerings**.
-   ![screen shot of core services VNet Peering settings ](../media/create-peering-on-coreservicesvnet.png)
+   ![Screenshot of core services VNet peering settings ](../media/create-peering-on-coreservicesvnet.png)
 
-1. On CoreServicesVnet | Peerings, select **+ Add**.
+1. On CoreServicesVnet \| Peerings, select **+ Add**.
 
 1. Use the information in the following table to create the peering.
 
-| **Section**                          | **Option**                                    | **Value**                             |
-| ------------------------------------ | --------------------------------------------- | ------------------------------------- |
-| This virtual network                 |                                               |                                       |
-|                                      | Peering link name                             | CoreServicesVnet-to-ManufacturingVnet |
-|                                      | Traffic to remote virtual network             | Allow (default)                       |
-|                                      | Traffic forwarded from remote virtual network | Allow (default)                       |
-|                                      | Virtual network gateway or Route Server       | None (default)                        |
-| Remote virtual network               |                                               |                                       |
-|                                      | Peering link name                             | ManufacturingVnet-to-CoreServicesVnet |
-|                                      | Virtual network deployment model              | Resource manager                      |
-|                                      | I know my resource ID                         | Not selected                          |
-|                                      | Subscription                                  | Select the Subscription provided      |
-|                                      | Virtual network                               | ManufacturingVnet                     |
-|                                      | Traffic to remote virtual network             | Allow (default)                       |
-|                                      | Traffic forwarded from remote virtual network | Allow (default)                       |
-|                                      | Virtual network gateway or Route Server       | None (default)                        |
-| Review your settings and select Add. |                                               |                                       |
-|                                      |                                               |                                       |
+   | **Section**                          | **Option**                                    | **Value**                             |
+   | ------------------------------------ | --------------------------------------------- | ------------------------------------- |
+   | This virtual network                 |                                               |                                       |
+   |                                      | Peering link name                             | CoreServicesVnet-to-ManufacturingVnet |
+   |                                      | Traffic to remote virtual network             | Allow (default)                       |
+   |                                      | Traffic forwarded from remote virtual network | Allow (default)                       |
+   |                                      | Virtual network gateway or Route Server       | None (default)                        |
+   | Remote virtual network               |                                               |                                       |
+   |                                      | Peering link name                             | ManufacturingVnet-to-CoreServicesVnet |
+   |                                      | Virtual network deployment model              | Resource manager                      |
+   |                                      | I know my resource ID                         | Not selected                          |
+   |                                      | Subscription                                  | Select the Subscription provided      |
+   |                                      | Virtual network                               | ManufacturingVnet                     |
+   |                                      | Traffic to remote virtual network             | Allow (default)                       |
+   |                                      | Traffic forwarded from remote virtual network | Allow (default)                       |
+   |                                      | Virtual network gateway or Route Server       | None (default)                        |
+   | Review your settings and select Add. |                                               |                                       |
+   |                                      |                                               |                                       |
 
- >**Note**: If you don't have a "MOC Subscription", use the subscription you've been using previously. It's just a name.
+   >**Note**: If you don't have a "MOC Subscription", use the subscription you've been using previously.
 
-1. In CoreServicesVnet | Peerings, verify that the **CoreServicesVnet-to-ManufacturingVnet** peering is listed.
+1. In CoreServicesVnet \| Peerings, verify that the **CoreServicesVnet-to-ManufacturingVnet** peering is listed.
 
 1. Under Virtual networks, select **ManufacturingVnet**, and verify the **ManufacturingVnet-to-CoreServicesVnet** peering is listed.
 
@@ -159,4 +160,4 @@ Congratulations! You have successful configured connectivity between VNets by ad
    Remove-AzResourceGroup -Name 'ContosoResourceGroup' -Force -AsJob
    ```
 
-    >**Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.
+   >**Note**: The command executes asynchronously (as determined by the -AsJob parameter), so while you will be able to run another PowerShell command immediately afterwards within the same PowerShell session, it will take a few minutes before the resource groups are actually removed.


### PR DESCRIPTION
# Module: 01

Noted throughout below units, there are a number of instances where the Pipe character "|" results in a markdown formatting error in Github.io pages. Have converted references to instead use the HTML delimited character code.

Fixes:
- Unit 4 
- Unit 6
- Unit 8

Changes proposed in this pull request:

- Minor updates to formatting and capitalization in Module 1, Unit 4
- Fix in formatting that results in github.io formatting error in instructions in Module 1, Unit 6
- Minor updates to formatting and capitalization in Module 1, Unit 8

### Relevant Screenshot(s)
![Screenshot 2024-08-19 151435](https://github.com/user-attachments/assets/bfa61bb1-fa2e-4352-b3f9-cbd3cf77f240)
