### PR TITLE
Corrected peering name for remote VNET

### DIFF
--- a/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
+++ b/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
@@ -26,7 +26,7 @@ In this unit, you will:
 
 ## Task 1: Create a Virtual Machine to test the configuration
 
-In this section, you will create a test VM on the Manufacturing VNet to test if you can access resources inside another Azure virtual network from your ManufacturingVnet.
+In this section, you will create a test VM on the  VNet to test if you can access resources inside another Azure virtual network from your Vnet.
 
 ### Create ManufacturingVM
 
@@ -113,7 +113,7 @@ In this section, you will create a test VM on the Manufacturing VNet to test if 
 
    | **Option**                                    | **Value**                             |
    | ------------------------------------ | --------------------------------------------- | 
-   | Peering link name    | `CoreServicesVnet-to-ManufacturingVnet` |
+   | Peering link name    | `ManufacturingVnet-to-CoreServicesVnet` |
    | Virtual network | ManufacturingVnet |
 
     **Remote virtual network peering settings**


### PR DESCRIPTION
# Module: 01
## Lab: Unit 8 - Create peerings

Fixes #255.

Changes proposed in this pull request:

- The name of the remote network peering is the same as the local name.
- Change the remote network peering name to `ManufacturingVnet-to-CoreServicesVnet`

### Relevant Issues link

