### PR TITLE
The text referred to "Remote Virtual Network Peering settings"  shoul…

### DIFF
--- a/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
+++ b/Instructions/Exercises/M01-Unit 8 Connect two Azure Virtual Networks using global virtual network peering.md
@@ -135,7 +135,7 @@ In this section, you will create a test VM on the  VNet to test if you can acces
     | ------------------------------------ | --------------------------------------------- | 
     | Peering link name | `CoreServicesVnet-to-ManufacturingVnet` |
  
-    **Remote virtual network peering settings**
+    **Local virtual network peering settings**
    
     | **Option**                                    | **Value**                             |
     | ------------------------------------ | --------------------------------------------- | 


### PR DESCRIPTION
# Module: 01
## Lab/Demo:  Unit 8 Connect two Azure Virtual Networks using global virtual network peering

**Changes proposed in this pull request:**

Corrected the instructions for creating a peering connection. The text previously referred to "Remote Virtual Network Peering settings" when it should have stated "Local Virtual Network Peering settings."

### Relevant Issues link

